### PR TITLE
[Issue #1] Initial project setup for WPF application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,107 @@
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# User-specific files
+*.rsuser
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio cache files
+.vs/
+Generated\ Files/
+
+# Rider
+.idea/
+*.iml
+modules.xml
+workspace.xml
+
+# Test results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.pch
+*.pdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*.log
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+
+# NuGet Packages
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+
+# DotCover
+*.dotCover
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+nCrunchTemp_*
+
+# ReSharper
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.DotSettings.user
+
+# TeamCity
+TeamCity.xml
+
+# DotNetCore
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# Env files
+.env
+.env.*
+!.env.example
+
+# Operations Management Suite (OMS) instrumentation key and host entry
+Logging.Mode=VisualStudio
+HockeyAppSampleiOSCrashOnly.sln.ideobjecthistory

--- a/AiDevTest1.Application/AiDevTest1.Application.csproj
+++ b/AiDevTest1.Application/AiDevTest1.Application.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\AiDevTest1.Domain\AiDevTest1.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/AiDevTest1.Application/Class1.cs
+++ b/AiDevTest1.Application/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace AiDevTest1.Application;
+
+public class Class1
+{
+
+}

--- a/AiDevTest1.Domain/AiDevTest1.Domain.csproj
+++ b/AiDevTest1.Domain/AiDevTest1.Domain.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/AiDevTest1.Domain/Class1.cs
+++ b/AiDevTest1.Domain/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace AiDevTest1.Domain;
+
+public class Class1
+{
+
+}

--- a/AiDevTest1.Infrastructure/AiDevTest1.Infrastructure.csproj
+++ b/AiDevTest1.Infrastructure/AiDevTest1.Infrastructure.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\AiDevTest1.Application\AiDevTest1.Application.csproj" />
+    <ProjectReference Include="..\AiDevTest1.Domain\AiDevTest1.Domain.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/AiDevTest1.Infrastructure/Class1.cs
+++ b/AiDevTest1.Infrastructure/Class1.cs
@@ -1,0 +1,6 @@
+﻿namespace AiDevTest1.Infrastructure;
+
+public class Class1
+{
+
+}

--- a/AiDevTest1.WpfApp/AiDevTest1.WpfApp.csproj
+++ b/AiDevTest1.WpfApp/AiDevTest1.WpfApp.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AiDevTest1.Application\AiDevTest1.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/AiDevTest1.WpfApp/App.xaml
+++ b/AiDevTest1.WpfApp/App.xaml
@@ -1,0 +1,8 @@
+﻿<Application x:Class="AiDevTest1.WpfApp.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:AiDevTest1.WpfApp">
+    <Application.Resources>
+
+    </Application.Resources>
+</Application>

--- a/AiDevTest1.WpfApp/App.xaml.cs
+++ b/AiDevTest1.WpfApp/App.xaml.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace AiDevTest1.WpfApp
+{
+  /// <summary>
+  /// Interaction logic for App.xaml
+  /// </summary>
+  public partial class App : Application
+  {
+    private IHost _host;
+
+    public App()
+    {
+      _host = Host.CreateDefaultBuilder()
+          .ConfigureServices((context, services) =>
+          {
+            ConfigureServices(services);
+          })
+          .Build();
+    }
+
+    private void ConfigureServices(IServiceCollection services)
+    {
+      // Register services here
+      // e.g., services.AddSingleton<IMyService, MyService>();
+
+      // Register Views and ViewModels
+      services.AddSingleton<MainWindow>();
+      // e.g., services.AddTransient<MyViewModel>();
+    }
+
+    protected override async void OnStartup(StartupEventArgs e)
+    {
+      await _host.StartAsync();
+
+      var mainWindow = _host.Services.GetRequiredService<MainWindow>();
+      mainWindow.Show();
+
+      base.OnStartup(e);
+    }
+
+    protected override async void OnExit(ExitEventArgs e)
+    {
+      using (_host)
+      {
+        await _host.StopAsync(TimeSpan.FromSeconds(5)); // Allow 5 seconds for graceful shutdown
+      }
+
+      base.OnExit(e);
+    }
+  }
+}

--- a/AiDevTest1.WpfApp/App.xaml.cs
+++ b/AiDevTest1.WpfApp/App.xaml.cs
@@ -9,7 +9,7 @@ namespace AiDevTest1.WpfApp
   /// <summary>
   /// Interaction logic for App.xaml
   /// </summary>
-  public partial class App : Application
+  public partial class App : System.Windows.Application
   {
     private IHost _host;
 

--- a/AiDevTest1.WpfApp/AssemblyInfo.cs
+++ b/AiDevTest1.WpfApp/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/AiDevTest1.WpfApp/MainWindow.xaml
+++ b/AiDevTest1.WpfApp/MainWindow.xaml
@@ -1,0 +1,17 @@
+﻿<Window x:Class="AiDevTest1.WpfApp.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AiDevTest1.WpfApp"
+        mc:Ignorable="d"
+        Title="AiDevTest1 WPF App"
+        Height="450"
+        Width="800">
+    <Grid>
+        <TextBlock Text="Hello, WPF!"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   FontSize="24"/>
+    </Grid>
+</Window>

--- a/AiDevTest1.WpfApp/MainWindow.xaml.cs
+++ b/AiDevTest1.WpfApp/MainWindow.xaml.cs
@@ -1,5 +1,4 @@
-﻿using System.Text;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Documents;

--- a/AiDevTest1.WpfApp/MainWindow.xaml.cs
+++ b/AiDevTest1.WpfApp/MainWindow.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System.Text;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace AiDevTest1.WpfApp;
+
+/// <summary>
+/// Interaction logic for MainWindow.xaml
+/// </summary>
+public partial class MainWindow : Window
+{
+    public MainWindow()
+    {
+        InitializeComponent();
+    }
+}

--- a/AiDevTest1.sln
+++ b/AiDevTest1.sln
@@ -1,0 +1,76 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDevTest1.WpfApp", "AiDevTest1.WpfApp\AiDevTest1.WpfApp.csproj", "{36641861-B124-4222-8411-AC00F5614112}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDevTest1.Domain", "AiDevTest1.Domain\AiDevTest1.Domain.csproj", "{9913A51A-63F6-4949-B496-651ACF39989B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDevTest1.Application", "AiDevTest1.Application\AiDevTest1.Application.csproj", "{78B4ACAD-279E-4B64-8657-DFC043921A4C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AiDevTest1.Infrastructure", "AiDevTest1.Infrastructure\AiDevTest1.Infrastructure.csproj", "{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{36641861-B124-4222-8411-AC00F5614112}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Debug|x64.Build.0 = Debug|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Debug|x86.Build.0 = Debug|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Release|x64.ActiveCfg = Release|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Release|x64.Build.0 = Release|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Release|x86.ActiveCfg = Release|Any CPU
+		{36641861-B124-4222-8411-AC00F5614112}.Release|x86.Build.0 = Release|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Debug|x64.Build.0 = Debug|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Debug|x86.Build.0 = Debug|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Release|x64.ActiveCfg = Release|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Release|x64.Build.0 = Release|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Release|x86.ActiveCfg = Release|Any CPU
+		{9913A51A-63F6-4949-B496-651ACF39989B}.Release|x86.Build.0 = Release|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Debug|x64.Build.0 = Debug|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Debug|x86.Build.0 = Debug|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Release|x64.ActiveCfg = Release|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Release|x64.Build.0 = Release|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Release|x86.ActiveCfg = Release|Any CPU
+		{78B4ACAD-279E-4B64-8657-DFC043921A4C}.Release|x86.Build.0 = Release|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Debug|x64.Build.0 = Debug|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Debug|x86.Build.0 = Debug|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Release|x64.ActiveCfg = Release|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Release|x64.Build.0 = Release|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Release|x86.ActiveCfg = Release|Any CPU
+		{4FF713BA-A5F3-4CB0-A4A0-C91CF8605EEB}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Resolves #1

## 概要
WPF アプリケーション (.NET 8) の初期プロジェクト構造をセットアップしました。
クリーンアーキテクチャガイドラインに基づき、以下のプロジェクト構成としました。

- AiDevTest1.sln (ソリューション)
- AiDevTest1.WpfApp (Presentation Layer)
- AiDevTest1.Domain (Domain Layer)
- AiDevTest1.Application (Application Layer)
- AiDevTest1.Infrastructure (Infrastructure Layer)

## 主な変更点
- 各レイヤープロジェクトの作成とソリューションへの追加
- プロジェクト間の参照設定
- AiDevTest1.WpfApp 内の基本的なフォルダ構造作成
- Microsoft.Extensions.Hosting の追加 (AiDevTest1.WpfApp)
- App.xaml.cs でのホストベース起動とDI準備
- MainWindow.xaml の初期表示設定
- .gitignore ファイルの更新 (C# 標準)

## 確認事項
- アプリケーション (AiDevTest1.WpfApp.exe) がビルド・実行可能であること。
- "Hello, WPF!" と表示されるウィンドウが起動すること。