### PR TITLE
Implement Dependency Injection Setup (Issue #2)

### DIFF
--- a/AiDevTest1.Application/Interfaces/IFileUploadService.cs
+++ b/AiDevTest1.Application/Interfaces/IFileUploadService.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace AiDevTest1.Application.Interfaces
+{
+  public interface IFileUploadService
+  {
+    Task UploadFileAsync(string filePath, string destinationPath);
+  }
+}

--- a/AiDevTest1.Application/Interfaces/ILogWriteService.cs
+++ b/AiDevTest1.Application/Interfaces/ILogWriteService.cs
@@ -1,0 +1,7 @@
+namespace AiDevTest1.Application.Interfaces
+{
+  public interface ILogWriteService
+  {
+    void Log(string message);
+  }
+}

--- a/AiDevTest1.Infrastructure/Services/FileUploadService.cs
+++ b/AiDevTest1.Infrastructure/Services/FileUploadService.cs
@@ -1,0 +1,16 @@
+using AiDevTest1.Application.Interfaces;
+using System;
+using System.Threading.Tasks;
+
+namespace AiDevTest1.Infrastructure.Services
+{
+  public class FileUploadService : IFileUploadService
+  {
+    public Task UploadFileAsync(string filePath, string destinationPath)
+    {
+      // ダミー実装: コンソールに出力するだけ
+      Console.WriteLine($"[FileUpload]: Uploading {filePath} to {destinationPath}");
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/AiDevTest1.Infrastructure/Services/LogWriteService.cs
+++ b/AiDevTest1.Infrastructure/Services/LogWriteService.cs
@@ -1,0 +1,14 @@
+using AiDevTest1.Application.Interfaces;
+using System;
+
+namespace AiDevTest1.Infrastructure.Services
+{
+  public class LogWriteService : ILogWriteService
+  {
+    public void Log(string message)
+    {
+      // ダミー実装: コンソールに出力するだけ
+      Console.WriteLine($"[Log]: {message}");
+    }
+  }
+}

--- a/AiDevTest1.WpfApp/AiDevTest1.WpfApp.csproj
+++ b/AiDevTest1.WpfApp/AiDevTest1.WpfApp.csproj
@@ -9,11 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\AiDevTest1.Application\AiDevTest1.Application.csproj" />
+    <ProjectReference Include="..\AiDevTest1.Infrastructure\AiDevTest1.Infrastructure.csproj" />
   </ItemGroup>
 
 </Project>

--- a/AiDevTest1.WpfApp/MainWindow.xaml.cs
+++ b/AiDevTest1.WpfApp/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using AiDevTest1.WpfApp.ViewModels;
 
 namespace AiDevTest1.WpfApp;
 
@@ -15,8 +16,12 @@ namespace AiDevTest1.WpfApp;
 /// </summary>
 public partial class MainWindow : Window
 {
-    public MainWindow()
+    private readonly MainWindowViewModel _viewModel;
+
+    public MainWindow(MainWindowViewModel viewModel)
     {
         InitializeComponent();
+        _viewModel = viewModel;
+        DataContext = _viewModel;
     }
 }

--- a/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
+++ b/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,10 @@
+namespace AiDevTest1.WpfApp.ViewModels
+{
+  public class MainWindowViewModel
+  {
+    // ダミーViewModel: 現時点では空
+    public MainWindowViewModel()
+    {
+    }
+  }
+}


### PR DESCRIPTION
This PR implements the dependency injection setup for the WPF application as described in Issue #2. 

Changes include:
- Added `Microsoft.Extensions.DependencyInjection` and `Microsoft.Extensions.Hosting` NuGet packages.
- Created dummy services (`ILogWriteService`, `IFileUploadService`) and `MainWindowViewModel` for DI registration testing.
- Configured `App.xaml.cs` to use `IHost` for DI container setup and service registration.
- Modified `MainWindow.xaml.cs` to receive `MainWindowViewModel` via constructor injection.
- Added project reference from `AiDevTest1.WpfApp` to `AiDevTest1.Infrastructure`.
- Resolved compiler warnings related to nullable properties in `App.xaml.cs`.
- Added a comment to Issue #15 regarding the discussion on `IFileUploadService` lifetime.