### PR TITLE
[Issue #16] FileUploadServiceにリトライロジックを実装

### DIFF
--- a/AiDevTest1.Infrastructure/Services/FileUploadService.cs
+++ b/AiDevTest1.Infrastructure/Services/FileUploadService.cs
@@ -1,6 +1,7 @@
 using AiDevTest1.Application.Interfaces;
 using AiDevTest1.Application.Models;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
@@ -24,6 +25,7 @@ namespace AiDevTest1.Infrastructure.Services
 
     /// <summary>
     /// ログファイルをIoT Hub経由でBlobストレージにアップロードします
+    /// リトライ機能付き（最大3回、間隔5秒）
     /// </summary>
     /// <returns>アップロード操作の結果</returns>
     public async Task<Result> UploadLogFileAsync()
@@ -53,47 +55,104 @@ namespace AiDevTest1.Infrastructure.Services
         var fileName = Path.GetFileName(logFilePath);
         var blobName = fileName;
 
-        // 4. IIoTHubClientを使用してSAS URIを取得
-        var sasUriResult = await _ioTHubClient.GetFileUploadSasUriAsync(blobName);
-        if (sasUriResult.IsFailure)
-        {
-          return Result.Failure($"SAS URI取得に失敗しました: {sasUriResult.ErrorMessage}");
-        }
+        // 4. リトライロジック付きでアップロード処理を実行
+        const int maxRetries = 3;
+        const int retryDelayMs = 5000; // 5秒
+        var attemptErrors = new List<string>();
 
-        // 5. 取得したSAS URIとファイル内容でアップロードを実行
-        if (string.IsNullOrEmpty(sasUriResult.SasUri))
+        for (int attempt = 1; attempt <= maxRetries; attempt++)
         {
-          return Result.Failure("SAS URIが空です");
-        }
-
-        var uploadResult = await _ioTHubClient.UploadToBlobAsync(sasUriResult.SasUri, fileContent);
-        if (uploadResult.IsFailure)
-        {
-          // アップロード失敗を通知
-          if (!string.IsNullOrEmpty(sasUriResult.CorrelationId))
+          try
           {
-            await _ioTHubClient.NotifyFileUploadCompleteAsync(sasUriResult.CorrelationId, false);
+            // SAS URI取得
+            var sasUriResult = await _ioTHubClient.GetFileUploadSasUriAsync(blobName);
+            if (sasUriResult.IsFailure)
+            {
+              var error = $"試行{attempt}: SAS URI取得に失敗 - {sasUriResult.ErrorMessage}";
+              attemptErrors.Add(error);
+
+              if (attempt == maxRetries)
+              {
+                break; // 最後の試行なのでループを抜ける
+              }
+
+              await Task.Delay(retryDelayMs);
+              continue;
+            }
+
+            // SAS URIの検証
+            if (string.IsNullOrEmpty(sasUriResult.SasUri))
+            {
+              var error = $"試行{attempt}: SAS URIが空";
+              attemptErrors.Add(error);
+
+              if (attempt == maxRetries)
+              {
+                break;
+              }
+
+              await Task.Delay(retryDelayMs);
+              continue;
+            }
+
+            // Blobアップロード実行
+            var uploadResult = await _ioTHubClient.UploadToBlobAsync(sasUriResult.SasUri, fileContent);
+            if (uploadResult.IsFailure)
+            {
+              var error = $"試行{attempt}: Blobアップロードに失敗 - {uploadResult.ErrorMessage}";
+              attemptErrors.Add(error);
+
+              if (attempt == maxRetries)
+              {
+                // 最後の試行で失敗した場合、失敗を通知
+                if (!string.IsNullOrEmpty(sasUriResult.CorrelationId))
+                {
+                  await _ioTHubClient.NotifyFileUploadCompleteAsync(sasUriResult.CorrelationId, false);
+                }
+                break;
+              }
+
+              await Task.Delay(retryDelayMs);
+              continue;
+            }
+
+            // 成功時の処理
+            if (string.IsNullOrEmpty(sasUriResult.CorrelationId))
+            {
+              return Result.Failure("相関IDが空です");
+            }
+
+            // アップロード成功を通知
+            var notifyResult = await _ioTHubClient.NotifyFileUploadCompleteAsync(sasUriResult.CorrelationId, true);
+            if (notifyResult.IsFailure)
+            {
+              return Result.Failure($"アップロード完了通知に失敗しました: {notifyResult.ErrorMessage}");
+            }
+
+            return Result.Success();
           }
-          return Result.Failure($"ファイルアップロードに失敗しました: {uploadResult.ErrorMessage}");
+          catch (Exception ex)
+          {
+            var error = $"試行{attempt}: 予期しないエラー - {ex.Message}";
+            attemptErrors.Add(error);
+
+            if (attempt == maxRetries)
+            {
+              break;
+            }
+
+            await Task.Delay(retryDelayMs);
+          }
         }
 
-        // 6. アップロード成功を通知
-        if (string.IsNullOrEmpty(sasUriResult.CorrelationId))
-        {
-          return Result.Failure("相関IDが空です");
-        }
-
-        var notifyResult = await _ioTHubClient.NotifyFileUploadCompleteAsync(sasUriResult.CorrelationId, true);
-        if (notifyResult.IsFailure)
-        {
-          return Result.Failure($"アップロード完了通知に失敗しました: {notifyResult.ErrorMessage}");
-        }
-
-        return Result.Success();
+        // 全ての試行が失敗した場合
+        var combinedErrorMessage = $"ファイルアップロードが{maxRetries}回の試行すべてで失敗しました。\n" +
+                                   string.Join("\n", attemptErrors);
+        return Result.Failure(combinedErrorMessage);
       }
       catch (Exception ex)
       {
-        return Result.Failure($"予期しないエラーが発生しました: {ex.Message}");
+        return Result.Failure($"ファイルアップロード処理で予期しないエラーが発生しました: {ex.Message}");
       }
     }
   }


### PR DESCRIPTION
## 概要
FileUploadServiceにAzure IoT Hubへのファイルアップロード処理（SAS URI取得を含む）のリトライロジックを実装しました。

## 変更内容

### 実装した機能
- **リトライ機能**: 最大3回、間隔5秒でアップロード処理をリトライ
- **リトライ対象**: SAS URI取得 + Blobアップロード処理
- **エラー追跡**: 各試行のエラーを蓄積し、最終的なエラーメッセージに含める
- **適切な通知**: 最後の試行で失敗した場合に`NotifyFileUploadCompleteAsync(correlationId, false)`を呼び出し

### 主な変更点
1. `System.Collections.Generic`のusingディレクティブを追加
2. メソッドコメントにリトライ機能の説明を追加
3. リトライループ（1〜3回）を実装
4. 各試行でのエラーを`attemptErrors`リストに蓄積
5. 試行間に`Task.Delay(5000)`で5秒待機
6. 成功時は即座にループを抜けて成功を返す
7. 全試行失敗時は詳細なエラーメッセージを返す

## 受け入れ基準の確認
- ✅ SAS URI取得およびBlobアップロード処理が失敗した場合にリトライが行われる
- ✅ リトライは最大3回まで行われる
- ✅ 各リトライの間には5秒間の待機時間が設けられる
- ✅ 3回リトライしても成功しない場合は、最終的にアップロード失敗として処理される
- ✅ リトライ処理中もUIブロッキングは継続される（UIブロッキングの制御はViewModelが行う想定）

## テスト
既存のテストは影響を受けません。リトライロジックは内部実装の詳細であり、外部インターフェースは変更されていません。

Closes #16