### PR TITLE
feat: MainWindowとFileUploadServiceの連携を実装 #17

### DIFF
--- a/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
+++ b/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
@@ -72,17 +72,16 @@ namespace AiDevTest1.WpfApp.ViewModels
         {
           System.Diagnostics.Debug.WriteLine("ログの書き込みが成功しました。");
 
-          // TODO: #15, #16 実装後にファイルアップロード処理を追加
           // ログ書き込み成功時のみファイルアップロードを実行
-          // var uploadResult = await _fileUploadService.UploadLogFileAsync();
-          // if (uploadResult.IsSuccess)
-          // {
-          //   System.Diagnostics.Debug.WriteLine("ファイルアップロードが成功しました。");
-          // }
-          // else
-          // {
-          //   System.Diagnostics.Debug.WriteLine($"ファイルアップロードに失敗しました: {uploadResult.ErrorMessage}");
-          // }
+          var uploadResult = await _fileUploadService.UploadLogFileAsync();
+          if (uploadResult.IsSuccess)
+          {
+            System.Diagnostics.Debug.WriteLine("ファイルアップロードが成功しました。");
+          }
+          else
+          {
+            System.Diagnostics.Debug.WriteLine($"ファイルアップロードに失敗しました: {uploadResult.ErrorMessage}");
+          }
         }
         else
         {


### PR DESCRIPTION
## 概要

Issue #17「MainWindowとFileUploadService連携」を実装しました。

## 変更内容

- `MainWindowViewModel.ExecuteLogWriteAsync()` メソッドでログ書き込み成功後に `FileUploadService.UploadLogFileAsync()` を呼び出すように実装
- ファイルアップロードの結果（成功/失敗）を受け取って適切にログ出力
- 既存のUIブロッキング機構（try-finally構造）により、アップロード処理中も適切にUI制御
- TODOコメントを削除して実装完了

## 受け入れ基準の確認

- [x] ログ書き込み成功後に `FileUploadService.UploadLogFileAsync()` が呼び出される
- [x] アップロード結果（成功/失敗）を `MainWindowViewModel` が受け取り、後続処理の準備完了
- [x] アップロード処理中もUIブロッキングが適切に制御される

## テスト

- 既存のユニットテストは影響なし
- 統合テストでログ書き込み→ファイルアップロードの流れを確認

Closes #17