### PR TITLE
[タスク番号: 0018] MainWindowとDialogService連携 (成功/失敗表示)

### DIFF
--- a/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
+++ b/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using AiDevTest1.Application.Interfaces;
+using AiDevTest1.WpfApp.Helpers;
 using System;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -67,32 +68,36 @@ namespace AiDevTest1.WpfApp.ViewModels
         // ログエントリの書き込み実行
         var result = await _logWriteService.WriteLogEntryAsync();
 
-        // 結果の処理（今回は成功/失敗のログ出力のみ）
+        // NOTE: issue #18では IDialogService のDI注入が仕様とされていたが、
+        // issue #13のDialogService実装が未完了のため、暫定的に既存のDialogHelperを直接使用
+        // 将来的にはIDialogServiceインターフェースとDI注入に移行することを想定
+
         if (result.IsSuccess)
         {
-          System.Diagnostics.Debug.WriteLine("ログの書き込みが成功しました。");
-
           // ログ書き込み成功時のみファイルアップロードを実行
           var uploadResult = await _fileUploadService.UploadLogFileAsync();
           if (uploadResult.IsSuccess)
           {
-            System.Diagnostics.Debug.WriteLine("ファイルアップロードが成功しました。");
+            // 全処理成功
+            DialogHelper.ShowSuccess("処理が完了しました。");
           }
           else
           {
-            System.Diagnostics.Debug.WriteLine($"ファイルアップロードに失敗しました: {uploadResult.ErrorMessage}");
+            // ファイルアップロード失敗
+            DialogHelper.ShowFailure($"ファイルアップロードに失敗しました: {uploadResult.ErrorMessage}");
           }
         }
         else
         {
-          System.Diagnostics.Debug.WriteLine($"ログの書き込みに失敗しました: {result.ErrorMessage}");
+          // ログ書き込み失敗
+          DialogHelper.ShowFailure($"ログの書き込みに失敗しました: {result.ErrorMessage}");
           // ログ書き込み失敗時はファイルアップロードをスキップ
         }
       }
       catch (Exception ex)
       {
         // 予期しないエラーのハンドリング
-        System.Diagnostics.Debug.WriteLine($"予期しないエラーが発生しました: {ex.Message}");
+        DialogHelper.ShowFailure($"予期しないエラーが発生しました: {ex.Message}");
       }
       finally
       {


### PR DESCRIPTION
## 概要

GitHub issue #18を実装しました。`MainWindowViewModel`が`FileUploadService`のアップロード結果に基づいて成功/失敗ダイアログを表示するように修正しました。

## 変更内容

### `AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs`

1. **using文の追加**
   - `using AiDevTest1.WpfApp.Helpers;`を追加

2. **ダイアログ表示ロジックの実装**
   - `System.Diagnostics.Debug.WriteLine`を`DialogHelper`のメソッド呼び出しに置き換え
   - 処理結果に応じて適切なダイアログを表示：
     - 全処理成功時: `DialogHelper.ShowSuccess("処理が完了しました。")`
     - ログ書き込み失敗時: `DialogHelper.ShowFailure("ログの書き込みに失敗しました: エラーメッセージ")`
     - ファイルアップロード失敗時: `DialogHelper.ShowFailure("ファイルアップロードに失敗しました: エラーメッセージ")`
     - 予期しないエラー時: `DialogHelper.ShowFailure("予期しないエラーが発生しました: エラーメッセージ")`

3. **実装方針についてのコメント追加**
   - issue #18では`IDialogService`のDI注入が仕様とされていましたが、issue #13の`DialogService`実装が未完了のため、暫定的に既存の`DialogHelper`を直接使用
   - 将来的には`IDialogService`インターフェースとDI注入に移行することを想定

## 受け入れ基準

- [x] `MainWindowViewModel`のアップロード処理完了後、結果に応じて成功または失敗のダイアログが表示される
- [x] ダイアログには、要求仕様通りのメッセージ（"成功" または "失敗"）とOKボタンが表示される
- [x] `DialogHelper.ShowSuccess`または`ShowFailure`メソッドが適切に呼び出される

## 技術的な詳細

- 複数のダイアログが連続表示されることを避けるため、最終結果に基づいて1回のダイアログ表示としました
- 既存の`DialogHelper`クラスを活用することで、統一されたダイアログ表示を実現しています
- エラーメッセージには具体的な失敗理由を含めることで、ユーザーが問題を理解しやすくしています

## 関連Issue

Closes #18

## 依存関係

- 前提タスク: #10 (ViewModel実装), #13 (DialogServiceインターフェース定義と基本実装), #17 (MainWindowとFileUploadService連携)