### PR TITLE
feat: Add generic Result<T> class (#43)

### DIFF
--- a/AiDevTest1.Application/Models/Result.cs
+++ b/AiDevTest1.Application/Models/Result.cs
@@ -21,11 +21,11 @@ public class Result
   public string? ErrorMessage { get; }
 
   /// <summary>
-  /// プライベートコンストラクタ（ファクトリメソッドからのみ生成可能）
+  /// プロテクトコンストラクタ（ファクトリメソッドおよび派生クラスからのみ生成可能）
   /// </summary>
   /// <param name="isSuccess">成功フラグ</param>
   /// <param name="errorMessage">エラーメッセージ</param>
-  private Result(bool isSuccess, string? errorMessage)
+  protected Result(bool isSuccess, string? errorMessage)
   {
     IsSuccess = isSuccess;
     ErrorMessage = errorMessage;

--- a/AiDevTest1.Application/Models/Result{T}.cs
+++ b/AiDevTest1.Application/Models/Result{T}.cs
@@ -1,0 +1,74 @@
+namespace AiDevTest1.Application.Models;
+
+/// <summary>
+/// 操作の成功/失敗と値を表現するResultパターンのジェネリック実装
+/// </summary>
+/// <typeparam name="T">成功時に返される値の型</typeparam>
+public class Result<T> : Result
+{
+  /// <summary>
+  /// 成功時の値
+  /// </summary>
+  private readonly T? _value;
+
+  /// <summary>
+  /// 成功時の値を取得します
+  /// </summary>
+  /// <exception cref="InvalidOperationException">失敗結果の場合にアクセスするとスローされます</exception>
+  public T Value
+  {
+    get
+    {
+      if (IsFailure)
+      {
+        throw new InvalidOperationException($"Cannot access value of a failed result. Error: {ErrorMessage}");
+      }
+      return _value!;
+    }
+  }
+
+  /// <summary>
+  /// プライベートコンストラクタ（ファクトリメソッドからのみ生成可能）
+  /// </summary>
+  /// <param name="isSuccess">成功フラグ</param>
+  /// <param name="value">成功時の値</param>
+  /// <param name="errorMessage">エラーメッセージ</param>
+  private Result(bool isSuccess, T? value, string? errorMessage) : base(isSuccess, errorMessage)
+  {
+    _value = value;
+  }
+
+  /// <summary>
+  /// 成功結果を作成します
+  /// </summary>
+  /// <param name="value">成功時の値</param>
+  /// <returns>成功と値を表すResultインスタンス</returns>
+  public static Result<T> Success(T value)
+  {
+    if (value == null)
+    {
+      throw new ArgumentNullException(nameof(value), "Success result must have a value.");
+    }
+    return new Result<T>(true, value, null);
+  }
+
+  /// <summary>
+  /// 失敗結果を作成します
+  /// </summary>
+  /// <param name="errorMessage">エラーメッセージ</param>
+  /// <returns>失敗を表すResultインスタンス</returns>
+  public new static Result<T> Failure(string errorMessage)
+  {
+    if (string.IsNullOrWhiteSpace(errorMessage))
+    {
+      throw new ArgumentException("Error message cannot be null or whitespace.", nameof(errorMessage));
+    }
+    return new Result<T>(false, default, errorMessage);
+  }
+
+  /// <summary>
+  /// 暗黙的な型変換演算子（値からResult<T>へ）
+  /// </summary>
+  /// <param name="value">変換する値</param>
+  public static implicit operator Result<T>(T value) => Success(value);
+}

--- a/AiDevTest1.Tests/ResultGenericTests.cs
+++ b/AiDevTest1.Tests/ResultGenericTests.cs
@@ -1,0 +1,129 @@
+using AiDevTest1.Application.Models;
+using Xunit;
+
+namespace AiDevTest1.Tests;
+
+/// <summary>
+/// Result<T>クラスのユニットテスト
+/// </summary>
+public class ResultGenericTests
+{
+  [Fact]
+  public void Success_WithValidValue_CreatesSuccessResult()
+  {
+    // Arrange
+    const string expectedValue = "test value";
+
+    // Act
+    var result = Result<string>.Success(expectedValue);
+
+    // Assert
+    Assert.True(result.IsSuccess);
+    Assert.False(result.IsFailure);
+    Assert.Equal(expectedValue, result.Value);
+    Assert.Null(result.ErrorMessage);
+  }
+
+  [Fact]
+  public void Success_WithNullValue_ThrowsArgumentNullException()
+  {
+    // Act & Assert
+    Assert.Throws<ArgumentNullException>(() => Result<string?>.Success(null));
+  }
+
+  [Fact]
+  public void Failure_WithErrorMessage_CreatesFailureResult()
+  {
+    // Arrange
+    const string errorMessage = "Operation failed";
+
+    // Act
+    var result = Result<int>.Failure(errorMessage);
+
+    // Assert
+    Assert.False(result.IsSuccess);
+    Assert.True(result.IsFailure);
+    Assert.Equal(errorMessage, result.ErrorMessage);
+  }
+
+  [Fact]
+  public void Failure_WithNullErrorMessage_ThrowsArgumentException()
+  {
+    // Act & Assert
+    Assert.Throws<ArgumentException>(() => Result<int>.Failure(null!));
+  }
+
+  [Fact]
+  public void Failure_WithEmptyErrorMessage_ThrowsArgumentException()
+  {
+    // Act & Assert
+    Assert.Throws<ArgumentException>(() => Result<int>.Failure(string.Empty));
+  }
+
+  [Fact]
+  public void Failure_WithWhitespaceErrorMessage_ThrowsArgumentException()
+  {
+    // Act & Assert
+    Assert.Throws<ArgumentException>(() => Result<int>.Failure("   "));
+  }
+
+  [Fact]
+  public void Value_OnFailureResult_ThrowsInvalidOperationException()
+  {
+    // Arrange
+    var result = Result<int>.Failure("Error");
+
+    // Act & Assert
+    var exception = Assert.Throws<InvalidOperationException>(() => result.Value);
+    Assert.Contains("Cannot access value of a failed result", exception.Message);
+    Assert.Contains("Error", exception.Message);
+  }
+
+  [Fact]
+  public void ImplicitOperator_WithValue_CreatesSuccessResult()
+  {
+    // Arrange
+    const int expectedValue = 42;
+
+    // Act
+    Result<int> result = expectedValue;
+
+    // Assert
+    Assert.True(result.IsSuccess);
+    Assert.Equal(expectedValue, result.Value);
+  }
+
+  [Fact]
+  public void Success_WithComplexType_CreatesSuccessResult()
+  {
+    // Arrange
+    var expectedValue = new TestClass { Id = 1, Name = "Test" };
+
+    // Act
+    var result = Result<TestClass>.Success(expectedValue);
+
+    // Assert
+    Assert.True(result.IsSuccess);
+    Assert.Same(expectedValue, result.Value);
+  }
+
+  [Fact]
+  public void Success_WithValueType_CreatesSuccessResult()
+  {
+    // Arrange
+    var expectedValue = new DateTime(2024, 1, 1);
+
+    // Act
+    var result = Result<DateTime>.Success(expectedValue);
+
+    // Assert
+    Assert.True(result.IsSuccess);
+    Assert.Equal(expectedValue, result.Value);
+  }
+
+  private class TestClass
+  {
+    public int Id { get; init; }
+    public string Name { get; init; } = string.Empty;
+  }
+}


### PR DESCRIPTION
## 概要
操作の成功/失敗と値を表現するResult<T>ジェネリッククラスを追加しました。

## 変更内容
- Resultベースクラスを継承する`Result<T>`クラスを作成
- 継承のためResultコンストラクタをprivateからprotectedに変更
- 失敗結果に対してInvalidOperationExceptionをスローするValueプロパティを追加
- `Success(T)`と`Failure(string)`静的ファクトリメソッドを追加
- 値からResult<T>への暗黙的な型変換演算子を追加
- 10個のテストケースを含む包括的なユニットテストを作成
- C#ガイドラインのResultパターンベストプラクティスに準拠

## 関連Issue
Closes #43

## テスト
- [x] すべての新規テストが成功することを確認（10/10テスト成功）
- [x] 既存のテストに影響がないことを確認
- [x] プロジェクトが正常にビルドされることを確認

## チェックリスト
- [x] コードはC#ガイドラインに準拠している
- [x] SOLID原則に従っている（開放/閉鎖原則）
- [x] 適切なXMLドキュメントコメントを含む
- [x] 包括的なユニットテストを含む