### PR TITLE
feat: Add DomainException class (#44)

### DIFF
--- a/AiDevTest1.Domain/Exceptions/DomainException.cs
+++ b/AiDevTest1.Domain/Exceptions/DomainException.cs
@@ -1,0 +1,96 @@
+using System;
+
+namespace AiDevTest1.Domain.Exceptions
+{
+  /// <summary>
+  /// ドメイン層で発生する例外の基底クラス。
+  /// ビジネスルール違反やドメイン固有のエラーを表現します。
+  /// </summary>
+  public class DomainException : Exception
+  {
+    /// <summary>
+    /// エラーコード。エラーの種類を識別するために使用します。
+    /// </summary>
+    public string ErrorCode { get; }
+
+    /// <summary>
+    /// エラーカテゴリ。エラーを分類するために使用します。
+    /// </summary>
+    public string Category { get; }
+
+    /// <summary>
+    /// <see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="message">例外を説明するメッセージ。</param>
+    public DomainException(string message)
+        : base(message)
+    {
+      ErrorCode = GetType().Name.Replace("Exception", string.Empty);
+      Category = "Domain";
+    }
+
+    /// <summary>
+    /// <see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="message">例外を説明するメッセージ。</param>
+    /// <param name="errorCode">エラーコード。</param>
+    public DomainException(string message, string errorCode)
+        : base(message)
+    {
+      ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
+      Category = "Domain";
+    }
+
+    /// <summary>
+    /// <see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="message">例外を説明するメッセージ。</param>
+    /// <param name="errorCode">エラーコード。</param>
+    /// <param name="category">エラーカテゴリ。</param>
+    public DomainException(string message, string errorCode, string category)
+        : base(message)
+    {
+      ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
+      Category = category ?? "Domain";
+    }
+
+    /// <summary>
+    /// <see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="message">例外を説明するメッセージ。</param>
+    /// <param name="innerException">現在の例外の原因である例外。</param>
+    public DomainException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+      ErrorCode = GetType().Name.Replace("Exception", string.Empty);
+      Category = "Domain";
+    }
+
+    /// <summary>
+    /// <see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="message">例外を説明するメッセージ。</param>
+    /// <param name="errorCode">エラーコード。</param>
+    /// <param name="innerException">現在の例外の原因である例外。</param>
+    public DomainException(string message, string errorCode, Exception innerException)
+        : base(message, innerException)
+    {
+      ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
+      Category = "Domain";
+    }
+
+    /// <summary>
+    /// <see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="message">例外を説明するメッセージ。</param>
+    /// <param name="errorCode">エラーコード。</param>
+    /// <param name="category">エラーカテゴリ。</param>
+    /// <param name="innerException">現在の例外の原因である例外。</param>
+    public DomainException(string message, string errorCode, string category, Exception innerException)
+        : base(message, innerException)
+    {
+      ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
+      Category = category ?? "Domain";
+    }
+  }
+}

--- a/AiDevTest1.Domain/Exceptions/DomainException.cs
+++ b/AiDevTest1.Domain/Exceptions/DomainException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Runtime.Serialization;
 
 namespace AiDevTest1.Domain.Exceptions
 {
@@ -6,8 +7,14 @@ namespace AiDevTest1.Domain.Exceptions
   /// ドメイン層で発生する例外の基底クラス。
   /// ビジネスルール違反やドメイン固有のエラーを表現します。
   /// </summary>
+  [Serializable]
   public class DomainException : Exception
   {
+    /// <summary>
+    /// デフォルトのエラーカテゴリ。
+    /// </summary>
+    private const string DefaultCategory = "Domain";
+
     /// <summary>
     /// エラーコード。エラーの種類を識別するために使用します。
     /// </summary>
@@ -23,10 +30,8 @@ namespace AiDevTest1.Domain.Exceptions
     /// </summary>
     /// <param name="message">例外を説明するメッセージ。</param>
     public DomainException(string message)
-        : base(message)
+        : this(message, null, null, null)
     {
-      ErrorCode = GetType().Name.Replace("Exception", string.Empty);
-      Category = "Domain";
     }
 
     /// <summary>
@@ -35,10 +40,8 @@ namespace AiDevTest1.Domain.Exceptions
     /// <param name="message">例外を説明するメッセージ。</param>
     /// <param name="errorCode">エラーコード。</param>
     public DomainException(string message, string errorCode)
-        : base(message)
+        : this(message, errorCode, null, null)
     {
-      ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
-      Category = "Domain";
     }
 
     /// <summary>
@@ -51,7 +54,7 @@ namespace AiDevTest1.Domain.Exceptions
         : base(message)
     {
       ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
-      Category = category ?? "Domain";
+      Category = category ?? DefaultCategory;
     }
 
     /// <summary>
@@ -60,10 +63,8 @@ namespace AiDevTest1.Domain.Exceptions
     /// <param name="message">例外を説明するメッセージ。</param>
     /// <param name="innerException">現在の例外の原因である例外。</param>
     public DomainException(string message, Exception innerException)
-        : base(message, innerException)
+        : this(message, null, null, innerException)
     {
-      ErrorCode = GetType().Name.Replace("Exception", string.Empty);
-      Category = "Domain";
     }
 
     /// <summary>
@@ -73,10 +74,8 @@ namespace AiDevTest1.Domain.Exceptions
     /// <param name="errorCode">エラーコード。</param>
     /// <param name="innerException">現在の例外の原因である例外。</param>
     public DomainException(string message, string errorCode, Exception innerException)
-        : base(message, innerException)
+        : this(message, errorCode, null, innerException)
     {
-      ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
-      Category = "Domain";
     }
 
     /// <summary>
@@ -90,7 +89,33 @@ namespace AiDevTest1.Domain.Exceptions
         : base(message, innerException)
     {
       ErrorCode = errorCode ?? GetType().Name.Replace("Exception", string.Empty);
-      Category = category ?? "Domain";
+      Category = category ?? DefaultCategory;
+    }
+
+    /// <summary>
+    /// シリアル化されたデータから<see cref="DomainException"/>クラスの新しいインスタンスを初期化します。
+    /// </summary>
+    /// <param name="info">シリアル化されたオブジェクトデータを保持するSerializationInfo。</param>
+    /// <param name="context">転送元または転送先に関するコンテキスト情報を含むStreamingContext。</param>
+    protected DomainException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+      ErrorCode = info.GetString(nameof(ErrorCode));
+      Category = info.GetString(nameof(Category));
+    }
+
+    /// <summary>
+    /// 例外に関する情報をSerializationInfoに設定します。
+    /// </summary>
+    /// <param name="info">シリアル化されたオブジェクトデータを保持するSerializationInfo。</param>
+    /// <param name="context">転送元または転送先に関するコンテキスト情報を含むStreamingContext。</param>
+    public override void GetObjectData(SerializationInfo info, StreamingContext context)
+    {
+      if (info == null) throw new ArgumentNullException(nameof(info));
+
+      info.AddValue(nameof(ErrorCode), ErrorCode);
+      info.AddValue(nameof(Category), Category);
+      base.GetObjectData(info, context);
     }
   }
 }

--- a/AiDevTest1.Tests/DomainExceptionTests.cs
+++ b/AiDevTest1.Tests/DomainExceptionTests.cs
@@ -1,0 +1,167 @@
+using AiDevTest1.Domain.Exceptions;
+using System;
+using Xunit;
+
+namespace AiDevTest1.Tests
+{
+  /// <summary>
+  /// DomainExceptionクラスのユニットテスト
+  /// </summary>
+  public class DomainExceptionTests
+  {
+    [Fact]
+    public void Constructor_WithMessage_SetsPropertiesCorrectly()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+
+      // Act
+      var exception = new DomainException(message);
+
+      // Assert
+      Assert.Equal(message, exception.Message);
+      Assert.Equal("Domain", exception.ErrorCode);
+      Assert.Equal("Domain", exception.Category);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAndErrorCode_SetsPropertiesCorrectly()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+      const string errorCode = "TEST_ERROR";
+
+      // Act
+      var exception = new DomainException(message, errorCode);
+
+      // Assert
+      Assert.Equal(message, exception.Message);
+      Assert.Equal(errorCode, exception.ErrorCode);
+      Assert.Equal("Domain", exception.Category);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageErrorCodeAndCategory_SetsPropertiesCorrectly()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+      const string errorCode = "TEST_ERROR";
+      const string category = "Validation";
+
+      // Act
+      var exception = new DomainException(message, errorCode, category);
+
+      // Assert
+      Assert.Equal(message, exception.Message);
+      Assert.Equal(errorCode, exception.ErrorCode);
+      Assert.Equal(category, exception.Category);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageAndInnerException_SetsPropertiesCorrectly()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+      var innerException = new InvalidOperationException("Inner exception");
+
+      // Act
+      var exception = new DomainException(message, innerException);
+
+      // Assert
+      Assert.Equal(message, exception.Message);
+      Assert.Equal("Domain", exception.ErrorCode);
+      Assert.Equal("Domain", exception.Category);
+      Assert.Same(innerException, exception.InnerException);
+    }
+
+    [Fact]
+    public void Constructor_WithMessageErrorCodeAndInnerException_SetsPropertiesCorrectly()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+      const string errorCode = "TEST_ERROR";
+      var innerException = new InvalidOperationException("Inner exception");
+
+      // Act
+      var exception = new DomainException(message, errorCode, innerException);
+
+      // Assert
+      Assert.Equal(message, exception.Message);
+      Assert.Equal(errorCode, exception.ErrorCode);
+      Assert.Equal("Domain", exception.Category);
+      Assert.Same(innerException, exception.InnerException);
+    }
+
+    [Fact]
+    public void Constructor_WithAllParameters_SetsPropertiesCorrectly()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+      const string errorCode = "TEST_ERROR";
+      const string category = "Validation";
+      var innerException = new InvalidOperationException("Inner exception");
+
+      // Act
+      var exception = new DomainException(message, errorCode, category, innerException);
+
+      // Assert
+      Assert.Equal(message, exception.Message);
+      Assert.Equal(errorCode, exception.ErrorCode);
+      Assert.Equal(category, exception.Category);
+      Assert.Same(innerException, exception.InnerException);
+    }
+
+    [Fact]
+    public void Constructor_WithNullErrorCode_UsesDefaultErrorCode()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+
+      // Act
+      var exception = new DomainException(message, (string)null);
+
+      // Assert
+      Assert.Equal("Domain", exception.ErrorCode);
+    }
+
+    [Fact]
+    public void Constructor_WithNullCategory_UsesDefaultCategory()
+    {
+      // Arrange
+      const string message = "Test domain exception";
+      const string errorCode = "TEST_ERROR";
+
+      // Act
+      var exception = new DomainException(message, errorCode, (string)null);
+
+      // Assert
+      Assert.Equal("Domain", exception.Category);
+    }
+
+    [Fact]
+    public void DerivedClass_AutomaticallyGeneratesErrorCodeFromClassName()
+    {
+      // Act
+      var exception = new TestDomainException("Test message");
+
+      // Assert
+      Assert.Equal("TestDomain", exception.ErrorCode);
+    }
+
+    [Fact]
+    public void DomainException_IsTypeOfException()
+    {
+      // Arrange
+      var exception = new DomainException("Test");
+
+      // Assert
+      Assert.IsAssignableFrom<Exception>(exception);
+    }
+
+    // 派生クラスのテスト用
+    private class TestDomainException : DomainException
+    {
+      public TestDomainException(string message) : base(message) { }
+    }
+  }
+}


### PR DESCRIPTION
## 概要
ドメイン層で発生する例外の基底クラスとしてDomainExceptionを追加しました。

## 変更内容
- Domain層に`DomainException`基底クラスを作成
- エラー分類のための`ErrorCode`と`Category`プロパティを追加
- 様々なユースケースに対応する複数のコンストラクタを実装
- 未提供の場合、クラス名から自動的にErrorCodeを生成
- 10個のテストケースを含む包括的なユニットテストを作成
- DDDの原則とC#の例外処理ベストプラクティスに準拠

## 関連Issue
Closes #44

## テスト
- [x] すべての新規テストが成功することを確認（10/10テスト成功）
- [x] 既存のテストに影響がないことを確認（全120テスト成功）
- [x] プロジェクトが正常にビルドされることを確認

## チェックリスト
- [x] コードはC#ガイドラインに準拠している
- [x] DDDの原則に従っている
- [x] 適切なXMLドキュメントコメントを含む
- [x] 包括的なユニットテストを含む