### PR TITLE
feat: Issue #46 - BlobName Value Objectの実装

### DIFF
--- a/AiDevTest1.Application/Interfaces/IIoTHubClient.cs
+++ b/AiDevTest1.Application/Interfaces/IIoTHubClient.cs
@@ -1,5 +1,6 @@
 using System.Threading.Tasks;
 using AiDevTest1.Application.Models;
+using AiDevTest1.Domain.ValueObjects;
 
 namespace AiDevTest1.Application.Interfaces;
 
@@ -13,7 +14,7 @@ public interface IIoTHubClient
   /// </summary>
   /// <param name="blobName">アップロードするファイルのBlob名</param>
   /// <returns>SAS URIと相関IDを含む結果</returns>
-  Task<SasUriResult> GetFileUploadSasUriAsync(string blobName);
+  Task<SasUriResult> GetFileUploadSasUriAsync(BlobName blobName);
 
   /// <summary>
   /// 指定されたSAS URIを使用してファイルをBlobストレージにアップロードします

--- a/AiDevTest1.Domain/ValueObjects/BlobName.cs
+++ b/AiDevTest1.Domain/ValueObjects/BlobName.cs
@@ -1,0 +1,161 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace AiDevTest1.Domain.ValueObjects
+{
+  /// <summary>
+  /// Azure Blob Storage用のBlob名を表すValue Object
+  /// </summary>
+  public readonly record struct BlobName
+  {
+    private readonly string _value;
+
+    /// <summary>
+    /// Blob名の最小長
+    /// </summary>
+    private const int MinLength = 1;
+
+    /// <summary>
+    /// Blob名の最大長
+    /// </summary>
+    private const int MaxLength = 1024;
+
+    /// <summary>
+    /// Azure Blob名として有効な文字のパターン
+    /// </summary>
+    /// <remarks>
+    /// Azure Blob Storageでは以下の文字が使用可能:
+    /// - 英数字 (a-z, A-Z, 0-9)
+    /// - ハイフン (-)
+    /// - アンダースコア (_)
+    /// - ピリオド (.)
+    /// - スラッシュ (/)
+    /// </remarks>
+    private static readonly Regex ValidBlobNamePattern = new(@"^[a-zA-Z0-9\-_\./]+$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// 予約されたBlob名（Azureの制約）
+    /// </summary>
+    private static readonly string[] ReservedNames = { ".", ".." };
+
+    /// <summary>
+    /// Blob名の値を取得します
+    /// </summary>
+    public string Value => _value ?? throw new InvalidOperationException("BlobName has not been properly initialized.");
+
+    /// <summary>
+    /// デバイスIDを含む完全なBlob名を取得します
+    /// </summary>
+    /// <param name="deviceId">デバイスID</param>
+    /// <returns>デバイスID/Blob名の形式の文字列</returns>
+    public string GetFullBlobName(string deviceId)
+    {
+      if (string.IsNullOrWhiteSpace(deviceId))
+      {
+        throw new ArgumentException("Device ID cannot be null or empty.", nameof(deviceId));
+      }
+
+      return $"{deviceId}/{Value}";
+    }
+
+    /// <summary>
+    /// BlobNameのコンストラクタ
+    /// </summary>
+    /// <param name="value">Blob名</param>
+    /// <exception cref="ArgumentException">Blob名が無効な場合</exception>
+    public BlobName(string value)
+    {
+      ValidateBlobName(value);
+      _value = value;
+    }
+
+    /// <summary>
+    /// 文字列からBlobNameへの暗黙的な型変換
+    /// </summary>
+    /// <param name="value">変換元の文字列</param>
+    public static implicit operator BlobName(string value) => new(value);
+
+    /// <summary>
+    /// BlobNameから文字列への暗黙的な型変換
+    /// </summary>
+    /// <param name="blobName">変換元のBlobName</param>
+    public static implicit operator string(BlobName blobName) => blobName.Value;
+
+    /// <summary>
+    /// ログファイル用のBlob名を作成します
+    /// </summary>
+    /// <param name="date">日付</param>
+    /// <returns>yyyy-MM-dd.log形式のBlobName</returns>
+    public static BlobName CreateForLogFile(DateTime date)
+    {
+      var fileName = $"{date:yyyy-MM-dd}.log";
+      return new BlobName(fileName);
+    }
+
+    /// <summary>
+    /// 今日の日付でログファイル用のBlob名を作成します
+    /// </summary>
+    /// <returns>今日の日付のログファイル用BlobName</returns>
+    public static BlobName CreateForTodayLogFile()
+    {
+      return CreateForLogFile(DateTime.Today);
+    }
+
+    /// <summary>
+    /// Blob名の妥当性を検証します
+    /// </summary>
+    /// <param name="value">検証するBlob名</param>
+    /// <exception cref="ArgumentException">Blob名が無効な場合</exception>
+    private static void ValidateBlobName(string value)
+    {
+      if (string.IsNullOrWhiteSpace(value))
+      {
+        throw new ArgumentException("Blob name cannot be null, empty, or whitespace.", nameof(value));
+      }
+
+      if (value.Length < MinLength || value.Length > MaxLength)
+      {
+        throw new ArgumentException($"Blob name length must be between {MinLength} and {MaxLength} characters. Actual length: {value.Length}.", nameof(value));
+      }
+
+      if (!ValidBlobNamePattern.IsMatch(value))
+      {
+        throw new ArgumentException($"Blob name contains invalid characters. Only alphanumeric characters, hyphens, underscores, periods, and forward slashes are allowed. Value: '{value}'", nameof(value));
+      }
+
+      // 予約名のチェック
+      if (Array.Exists(ReservedNames, reserved => string.Equals(value, reserved, StringComparison.OrdinalIgnoreCase)))
+      {
+        throw new ArgumentException($"Blob name '{value}' is reserved and cannot be used.", nameof(value));
+      }
+
+      // 連続するスラッシュのチェック
+      if (value.Contains("//"))
+      {
+        throw new ArgumentException("Blob name cannot contain consecutive forward slashes.", nameof(value));
+      }
+
+      // 先頭・末尾のスラッシュのチェック
+      if (value.StartsWith('/') || value.EndsWith('/'))
+      {
+        throw new ArgumentException("Blob name cannot start or end with a forward slash.", nameof(value));
+      }
+
+      // 先頭・末尾のピリオドのチェック（Azureの制約）
+      var segments = value.Split('/');
+      foreach (var segment in segments)
+      {
+        if (segment.StartsWith('.') || segment.EndsWith('.'))
+        {
+          throw new ArgumentException("Blob name segments cannot start or end with a period.", nameof(value));
+        }
+      }
+    }
+
+    /// <summary>
+    /// 文字列表現を返します
+    /// </summary>
+    /// <returns>Blob名の文字列表現</returns>
+    public override string ToString() => Value;
+  }
+}

--- a/AiDevTest1.Infrastructure/Services/FileUploadService.cs
+++ b/AiDevTest1.Infrastructure/Services/FileUploadService.cs
@@ -1,5 +1,6 @@
 using AiDevTest1.Application.Interfaces;
 using AiDevTest1.Application.Models;
+using AiDevTest1.Domain.ValueObjects;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -53,7 +54,7 @@ namespace AiDevTest1.Infrastructure.Services
         }
 
         // 3. blob名を生成 (yyyy-MM-dd.log形式)
-        var blobName = logFilePath.FileName;
+        BlobName blobName = logFilePath.FileName; // 暗黙的な型変換でBlobNameに変換
 
         // 4. リトライロジック付きでアップロード処理を実行
         const int maxRetries = 3;

--- a/AiDevTest1.Infrastructure/Services/IoTHubClient.cs
+++ b/AiDevTest1.Infrastructure/Services/IoTHubClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using AiDevTest1.Application.Interfaces;
 using AiDevTest1.Application.Models;
+using AiDevTest1.Domain.ValueObjects;
 using Microsoft.Azure.Devices.Client;
 using Microsoft.Azure.Devices.Client.Transport;
 using Microsoft.Extensions.Options;
@@ -60,13 +61,8 @@ public class IoTHubClient : IIoTHubClient, IDisposable
   /// </summary>
   /// <param name="blobName">アップロードするファイルのBlob名</param>
   /// <returns>SAS URIと相関IDを含む結果</returns>
-  public async Task<SasUriResult> GetFileUploadSasUriAsync(string blobName)
+  public async Task<SasUriResult> GetFileUploadSasUriAsync(BlobName blobName)
   {
-    if (string.IsNullOrWhiteSpace(blobName))
-    {
-      return SasUriResult.Failure("Blob name cannot be null or empty");
-    }
-
     if (_disposed)
     {
       return SasUriResult.Failure("IoTHubClient has been disposed");
@@ -75,7 +71,7 @@ public class IoTHubClient : IIoTHubClient, IDisposable
     try
     {
       // デバイスID/ファイル名の形式でBlob名を構築
-      var fullBlobName = $"{_deviceId}/{blobName}";
+      var fullBlobName = blobName.GetFullBlobName(_deviceId);
 
       // Azure IoT Hub SDKを使用してファイルアップロード用のSAS URIを取得
       var fileUploadSasUriRequest = new FileUploadSasUriRequest

--- a/AiDevTest1.Infrastructure/Services/MockIoTHubClient.cs
+++ b/AiDevTest1.Infrastructure/Services/MockIoTHubClient.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using AiDevTest1.Application.Interfaces;
 using AiDevTest1.Application.Models;
+using AiDevTest1.Domain.ValueObjects;
 
 namespace AiDevTest1.Infrastructure.Services;
 
@@ -30,13 +31,8 @@ public class MockIoTHubClient : IIoTHubClient
   /// </summary>
   /// <param name="blobName">アップロードするファイルのBlob名</param>
   /// <returns>SAS URIと相関IDを含む結果</returns>
-  public Task<SasUriResult> GetFileUploadSasUriAsync(string blobName)
+  public Task<SasUriResult> GetFileUploadSasUriAsync(BlobName blobName)
   {
-    if (string.IsNullOrWhiteSpace(blobName))
-    {
-      return Task.FromResult(SasUriResult.Failure("Blob name cannot be null or empty"));
-    }
-
     if (!_simulateSuccess)
     {
       return Task.FromResult(SasUriResult.Failure(_errorMessage));
@@ -44,7 +40,10 @@ public class MockIoTHubClient : IIoTHubClient
 
     // 成功時のモックデータを生成
     var correlationId = Guid.NewGuid().ToString();
-    var sasUri = $"https://mockstorageaccount.blob.core.windows.net/uploads/{blobName}?sv=2023-01-03&sr=b&sig=mock_signature&se=2024-12-31T23:59:59Z&sp=w";
+    // デバイスIDをモックで使用
+    var mockDeviceId = "mock-device-001";
+    var fullBlobName = blobName.GetFullBlobName(mockDeviceId);
+    var sasUri = $"https://mockstorageaccount.blob.core.windows.net/uploads/{fullBlobName}?sv=2023-01-03&sr=b&sig=mock_signature&se=2024-12-31T23:59:59Z&sp=w";
 
     return Task.FromResult(SasUriResult.Success(sasUri, correlationId));
   }

--- a/AiDevTest1.Tests/IoTHubClientTests.cs
+++ b/AiDevTest1.Tests/IoTHubClientTests.cs
@@ -1,4 +1,5 @@
 using AiDevTest1.Application.Models;
+using AiDevTest1.Domain.ValueObjects;
 using AiDevTest1.Infrastructure.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Options;
@@ -111,63 +112,6 @@ public class IoTHubClientTests
     exception.Message.Should().Contain("Failed to create DeviceClient");
   }
 
-  /// <summary>
-  /// GetFileUploadSasUriAsyncでnullのblobNameが渡された場合、失敗結果が返されることをテスト
-  /// </summary>
-  [Fact]
-  public async Task GetFileUploadSasUriAsync_WithNullBlobName_ReturnsFailure()
-  {
-    // Arrange
-    var authInfo = new AuthenticationInfo
-    {
-      ConnectionString = "HostName=test.azure-devices.net;DeviceId=test;SharedAccessKey=dGVzdA==",
-      DeviceId = "test-device"
-    };
-    var options = Options.Create(authInfo);
-
-    using var client = new IoTHubClient(options);
-
-    // Act
-    var result = await client.GetFileUploadSasUriAsync(null!);
-
-    // Assert
-    result.Should().NotBeNull();
-    result.IsSuccess.Should().BeFalse();
-    result.IsFailure.Should().BeTrue();
-    result.ErrorMessage.Should().Be("Blob name cannot be null or empty");
-    result.SasUri.Should().BeNull();
-    result.CorrelationId.Should().BeNull();
-  }
-
-  /// <summary>
-  /// GetFileUploadSasUriAsyncで空のblobNameが渡された場合、失敗結果が返されることをテスト
-  /// </summary>
-  [Theory]
-  [InlineData("")]
-  [InlineData("   ")]
-  public async Task GetFileUploadSasUriAsync_WithEmptyBlobName_ReturnsFailure(string emptyBlobName)
-  {
-    // Arrange
-    var authInfo = new AuthenticationInfo
-    {
-      ConnectionString = "HostName=test.azure-devices.net;DeviceId=test;SharedAccessKey=dGVzdA==",
-      DeviceId = "test-device"
-    };
-    var options = Options.Create(authInfo);
-
-    using var client = new IoTHubClient(options);
-
-    // Act
-    var result = await client.GetFileUploadSasUriAsync(emptyBlobName);
-
-    // Assert
-    result.Should().NotBeNull();
-    result.IsSuccess.Should().BeFalse();
-    result.IsFailure.Should().BeTrue();
-    result.ErrorMessage.Should().Be("Blob name cannot be null or empty");
-    result.SasUri.Should().BeNull();
-    result.CorrelationId.Should().BeNull();
-  }
 
   /// <summary>
   /// Disposeされた後にGetFileUploadSasUriAsyncを呼び出した場合、失敗結果が返されることをテスト
@@ -187,7 +131,7 @@ public class IoTHubClientTests
     client.Dispose();
 
     // Act
-    var result = await client.GetFileUploadSasUriAsync("test.log");
+    var result = await client.GetFileUploadSasUriAsync(new BlobName("test.log"));
 
     // Assert
     result.Should().NotBeNull();
@@ -505,7 +449,7 @@ public class IoTHubClientTests
     var options = Options.Create(authInfo);
 
     using var client = new IoTHubClient(options);
-    var blobName = "2023-12-25.log";
+    var blobName = new BlobName("2023-12-25.log");
 
     // Act
     // このテストは実際のAzure SDKに依存するため、実際の接続エラーが発生することが期待される

--- a/AiDevTest1.Tests/MockIoTHubClientTests.cs
+++ b/AiDevTest1.Tests/MockIoTHubClientTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Text;
 using System.Threading.Tasks;
 using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Domain.ValueObjects;
 using AiDevTest1.Infrastructure.Services;
 using Xunit;
 
@@ -17,7 +18,7 @@ namespace AiDevTest1.Tests
       var blobName = "test-file.log";
 
       // Act
-      var result = await client.GetFileUploadSasUriAsync(blobName);
+      var result = await client.GetFileUploadSasUriAsync(new BlobName(blobName));
 
       // Assert
       Assert.True(result.IsSuccess);
@@ -25,7 +26,7 @@ namespace AiDevTest1.Tests
       Assert.NotNull(result.SasUri);
       Assert.NotNull(result.CorrelationId);
       Assert.Null(result.ErrorMessage);
-      Assert.Contains(blobName, result.SasUri);
+      Assert.Contains("mock-device-001/" + blobName, result.SasUri); // モックではデバイスIDが付加される
       Assert.True(Guid.TryParse(result.CorrelationId, out _));
     }
 
@@ -38,7 +39,7 @@ namespace AiDevTest1.Tests
       var blobName = "test-file.log";
 
       // Act
-      var result = await client.GetFileUploadSasUriAsync(blobName);
+      var result = await client.GetFileUploadSasUriAsync(new BlobName(blobName));
 
       // Assert
       Assert.False(result.IsSuccess);
@@ -48,25 +49,6 @@ namespace AiDevTest1.Tests
       Assert.Equal(errorMessage, result.ErrorMessage);
     }
 
-    [Theory]
-    [InlineData(null)]
-    [InlineData("")]
-    [InlineData("   ")]
-    public async Task GetFileUploadSasUriAsync_WithInvalidBlobName_ShouldReturnFailure(string? invalidBlobName)
-    {
-      // Arrange
-      IIoTHubClient client = new MockIoTHubClient(simulateSuccess: true);
-
-      // Act
-      var result = await client.GetFileUploadSasUriAsync(invalidBlobName!);
-
-      // Assert
-      Assert.False(result.IsSuccess);
-      Assert.True(result.IsFailure);
-      Assert.Null(result.SasUri);
-      Assert.Null(result.CorrelationId);
-      Assert.Equal("Blob name cannot be null or empty", result.ErrorMessage);
-    }
 
     [Fact]
     public async Task UploadToBlobAsync_WithValidParameters_ShouldReturnSuccess()
@@ -216,7 +198,7 @@ namespace AiDevTest1.Tests
 
       // Act & Assert
       // Step 1: Get SAS URI
-      var sasResult = await client.GetFileUploadSasUriAsync(blobName);
+      var sasResult = await client.GetFileUploadSasUriAsync(new BlobName(blobName));
       Assert.True(sasResult.IsSuccess);
       Assert.NotNull(sasResult.SasUri);
       Assert.NotNull(sasResult.CorrelationId);
@@ -241,7 +223,7 @@ namespace AiDevTest1.Tests
 
       // Act & Assert
       // Step 1: Get SAS URI (should fail)
-      var sasResult = await client.GetFileUploadSasUriAsync(blobName);
+      var sasResult = await client.GetFileUploadSasUriAsync(new BlobName(blobName));
       Assert.False(sasResult.IsSuccess);
       Assert.Equal(errorMessage, sasResult.ErrorMessage);
 

--- a/AiDevTest1.Tests/ValueObjects/BlobNameTests.cs
+++ b/AiDevTest1.Tests/ValueObjects/BlobNameTests.cs
@@ -1,0 +1,321 @@
+using System;
+using AiDevTest1.Domain.ValueObjects;
+using Xunit;
+
+namespace AiDevTest1.Tests.ValueObjects
+{
+  /// <summary>
+  /// BlobName Value Objectのユニットテスト
+  /// </summary>
+  public class BlobNameTests
+  {
+    #region コンストラクタのテスト
+
+    [Theory]
+    [InlineData("test.log")]
+    [InlineData("2023-12-25.log")]
+    [InlineData("folder/file.txt")]
+    [InlineData("folder/subfolder/file.log")]
+    [InlineData("file-with-hyphens.txt")]
+    [InlineData("file_with_underscores.log")]
+    [InlineData("file.with.multiple.dots.txt")]
+    [InlineData("UPPERCASE.LOG")]
+    [InlineData("MixedCase.Log")]
+    [InlineData("123456789.log")]
+    [InlineData("a")] // 最小長
+    public void Constructor_WithValidBlobName_ShouldCreateInstance(string validName)
+    {
+      // Act
+      var blobName = new BlobName(validName);
+
+      // Assert
+      Assert.Equal(validName, blobName.Value);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    public void Constructor_WithNullOrWhiteSpace_ShouldThrowArgumentException(string? invalidName)
+    {
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(invalidName!));
+      Assert.Contains("Blob name cannot be null, empty, or whitespace", ex.Message);
+      Assert.Equal("value", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithTooLongName_ShouldThrowArgumentException()
+    {
+      // Arrange
+      var tooLongName = new string('a', 1025); // 最大長1024を超える
+
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(tooLongName));
+      Assert.Contains("Blob name length must be between 1 and 1024 characters", ex.Message);
+      Assert.Contains("Actual length: 1025", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("file with spaces.txt")]
+    [InlineData("file@name.txt")]
+    [InlineData("file#name.txt")]
+    [InlineData("file$name.txt")]
+    [InlineData("file%name.txt")]
+    [InlineData("file&name.txt")]
+    [InlineData("file*name.txt")]
+    [InlineData("file(name).txt")]
+    [InlineData("file[name].txt")]
+    [InlineData("file{name}.txt")]
+    [InlineData("file<name>.txt")]
+    [InlineData("file>name.txt")]
+    [InlineData("file|name.txt")]
+    [InlineData("file\\name.txt")] // バックスラッシュ
+    [InlineData("file\"name.txt")]
+    [InlineData("file'name.txt")]
+    [InlineData("file:name.txt")]
+    [InlineData("file;name.txt")]
+    [InlineData("file,name.txt")]
+    [InlineData("file?name.txt")]
+    [InlineData("file=name.txt")]
+    [InlineData("file+name.txt")]
+    public void Constructor_WithInvalidCharacters_ShouldThrowArgumentException(string invalidName)
+    {
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(invalidName));
+      Assert.Contains("Blob name contains invalid characters", ex.Message);
+      Assert.Contains($"Value: '{invalidName}'", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    public void Constructor_WithReservedNames_ShouldThrowArgumentException(string reservedName)
+    {
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(reservedName));
+      Assert.Contains($"Blob name '{reservedName}' is reserved and cannot be used", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("folder//file.txt")]
+    [InlineData("folder///file.txt")]
+    [InlineData("a//b//c.txt")]
+    public void Constructor_WithConsecutiveSlashes_ShouldThrowArgumentException(string invalidName)
+    {
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(invalidName));
+      Assert.Contains("Blob name cannot contain consecutive forward slashes", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("/file.txt")]
+    [InlineData("file.txt/")]
+    [InlineData("/file.txt/")]
+    [InlineData("/folder/file.txt")]
+    [InlineData("folder/file.txt/")]
+    public void Constructor_WithLeadingOrTrailingSlash_ShouldThrowArgumentException(string invalidName)
+    {
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(invalidName));
+      Assert.Contains("Blob name cannot start or end with a forward slash", ex.Message);
+    }
+
+    [Theory]
+    [InlineData(".file.txt")]
+    [InlineData("file.txt.")]
+    [InlineData("folder/.file.txt")]
+    [InlineData("folder/file.txt.")]
+    [InlineData(".folder/file.txt")]
+    [InlineData("folder./file.txt")]
+    public void Constructor_WithSegmentStartingOrEndingWithPeriod_ShouldThrowArgumentException(string invalidName)
+    {
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => new BlobName(invalidName));
+      Assert.Contains("Blob name segments cannot start or end with a period", ex.Message);
+    }
+
+    #endregion
+
+    #region 暗黙的型変換のテスト
+
+    [Fact]
+    public void ImplicitConversion_FromString_ShouldCreateBlobName()
+    {
+      // Arrange
+      string fileName = "test.log";
+
+      // Act
+      BlobName blobName = fileName;
+
+      // Assert
+      Assert.Equal(fileName, blobName.Value);
+    }
+
+    [Fact]
+    public void ImplicitConversion_ToString_ShouldReturnValue()
+    {
+      // Arrange
+      var blobName = new BlobName("test.log");
+
+      // Act
+      string value = blobName;
+
+      // Assert
+      Assert.Equal("test.log", value);
+    }
+
+    #endregion
+
+    #region GetFullBlobNameメソッドのテスト
+
+    [Theory]
+    [InlineData("device123", "test.log", "device123/test.log")]
+    [InlineData("IoT-Device-001", "2023-12-25.log", "IoT-Device-001/2023-12-25.log")]
+    [InlineData("sensor_01", "data/readings.csv", "sensor_01/data/readings.csv")]
+    public void GetFullBlobName_WithValidDeviceId_ShouldReturnFullPath(string deviceId, string fileName, string expected)
+    {
+      // Arrange
+      var blobName = new BlobName(fileName);
+
+      // Act
+      var fullName = blobName.GetFullBlobName(deviceId);
+
+      // Assert
+      Assert.Equal(expected, fullName);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("   ")]
+    public void GetFullBlobName_WithNullOrEmptyDeviceId_ShouldThrowArgumentException(string? invalidDeviceId)
+    {
+      // Arrange
+      var blobName = new BlobName("test.log");
+
+      // Act & Assert
+      var ex = Assert.Throws<ArgumentException>(() => blobName.GetFullBlobName(invalidDeviceId!));
+      Assert.Contains("Device ID cannot be null or empty", ex.Message);
+      Assert.Equal("deviceId", ex.ParamName);
+    }
+
+    #endregion
+
+    #region ファクトリメソッドのテスト
+
+    [Fact]
+    public void CreateForLogFile_WithSpecificDate_ShouldCreateCorrectBlobName()
+    {
+      // Arrange
+      var date = new DateTime(2023, 12, 25);
+
+      // Act
+      var blobName = BlobName.CreateForLogFile(date);
+
+      // Assert
+      Assert.Equal("2023-12-25.log", blobName.Value);
+    }
+
+    [Theory]
+    [InlineData(2024, 1, 1, "2024-01-01.log")]
+    [InlineData(2023, 12, 31, "2023-12-31.log")]
+    [InlineData(2025, 6, 15, "2025-06-15.log")]
+    public void CreateForLogFile_WithVariousDates_ShouldCreateCorrectFormat(int year, int month, int day, string expected)
+    {
+      // Arrange
+      var date = new DateTime(year, month, day);
+
+      // Act
+      var blobName = BlobName.CreateForLogFile(date);
+
+      // Assert
+      Assert.Equal(expected, blobName.Value);
+    }
+
+    [Fact]
+    public void CreateForTodayLogFile_ShouldCreateBlobNameWithTodayDate()
+    {
+      // Arrange
+      var expectedName = $"{DateTime.Today:yyyy-MM-dd}.log";
+
+      // Act
+      var blobName = BlobName.CreateForTodayLogFile();
+
+      // Assert
+      Assert.Equal(expectedName, blobName.Value);
+    }
+
+    #endregion
+
+    #region ToStringメソッドのテスト
+
+    [Theory]
+    [InlineData("test.log")]
+    [InlineData("folder/file.txt")]
+    [InlineData("2023-12-25.log")]
+    public void ToString_ShouldReturnValue(string fileName)
+    {
+      // Arrange
+      var blobName = new BlobName(fileName);
+
+      // Act
+      var result = blobName.ToString();
+
+      // Assert
+      Assert.Equal(fileName, result);
+    }
+
+    #endregion
+
+    #region Equalityのテスト
+
+    [Fact]
+    public void Equality_SameBlobNames_ShouldBeEqual()
+    {
+      // Arrange
+      var blobName1 = new BlobName("test.log");
+      var blobName2 = new BlobName("test.log");
+
+      // Act & Assert
+      Assert.Equal(blobName1, blobName2);
+      Assert.True(blobName1 == blobName2);
+      Assert.False(blobName1 != blobName2);
+      Assert.Equal(blobName1.GetHashCode(), blobName2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_DifferentBlobNames_ShouldNotBeEqual()
+    {
+      // Arrange
+      var blobName1 = new BlobName("test1.log");
+      var blobName2 = new BlobName("test2.log");
+
+      // Act & Assert
+      Assert.NotEqual(blobName1, blobName2);
+      Assert.False(blobName1 == blobName2);
+      Assert.True(blobName1 != blobName2);
+    }
+
+    #endregion
+
+    #region 初期化されていないインスタンスのテスト
+
+    [Fact]
+    public void Value_WhenNotInitialized_ShouldThrowInvalidOperationException()
+    {
+      // Arrange
+      var blobName = default(BlobName);
+
+      // Act & Assert
+      var ex = Assert.Throws<InvalidOperationException>(() => blobName.Value);
+      Assert.Equal("BlobName has not been properly initialized.", ex.Message);
+    }
+
+    #endregion
+  }
+}


### PR DESCRIPTION
## 概要
Issue #46に対応し、Azure Blob Storage用のBlobName Value Objectを実装しました。

## 変更内容

### 新規追加
- **BlobName Value Object** (`AiDevTest1.Domain/ValueObjects/BlobName.cs`)
  - Azure Blob名のドメインルールをカプセル化
  - 最小/最大長の検証（1-1024文字）
  - 有効な文字の検証（英数字、ハイフン、アンダースコア、ピリオド、スラッシュ）
  - 予約名の検証（`.`、`..`は無効）
  - フォーマット検証（連続スラッシュ、先頭末尾のスラッシュ/ピリオドは無効）
  - `GetFullBlobName(deviceId)` メソッドでデバイスID付きの完全なBlob名を生成
  - ログファイル用ファクトリメソッド（`CreateForLogFile`、`CreateForTodayLogFile`）

### 更新
- **IIoTHubClient インターフェース**
  - `GetFileUploadSasUriAsync` メソッドのパラメータを `string` から `BlobName` に変更
  
- **実装クラス**
  - `IoTHubClient`: BlobName Value Objectを使用するよう更新
  - `MockIoTHubClient`: BlobName Value Objectを使用するよう更新
  - `FileUploadService`: 暗黙的な型変換を利用してBlobNameを使用

### テスト
- **新規テスト** (`AiDevTest1.Tests/ValueObjects/BlobNameTests.cs`)
  - 76個の包括的なユニットテスト
  - コンストラクタ、暗黙的型変換、メソッド、等価性のテスト
  
- **既存テストの更新**
  - `IoTHubClientTests`: BlobName使用に更新
  - `MockIoTHubClientTests`: BlobName使用に更新、無効なblob名のテストを削除（Value Objectで検証されるため）

## メリット
- **型安全性の向上**: コンパイル時にBlob名の型チェックが可能
- **ドメインルールの明確化**: Azure Blob Storageの制約が明示的
- **バグの防止**: 無効なBlob名の使用を事前に防ぐ
- **保守性の向上**: Blob名に関するロジックが一箇所に集約

## テスト結果
- BlobNameTests: 76テスト成功 ✅
- IoTHubClientTests + MockIoTHubClientTests: 40テスト成功 ✅

## 関連Issue
Closes #46