### PR TITLE
refactor: LogEntryFactoryをDomain層に移動してDDDアーキテクチャを改善

### DIFF
--- a/AiDevTest1.Domain/Interfaces/ILogEntryFactory.cs
+++ b/AiDevTest1.Domain/Interfaces/ILogEntryFactory.cs
@@ -1,6 +1,6 @@
 using AiDevTest1.Domain.Models;
 
-namespace AiDevTest1.Application.Interfaces;
+namespace AiDevTest1.Domain.Interfaces;
 
 /// <summary>
 /// LogEntryオブジェクトを生成するファクトリのインターフェース

--- a/AiDevTest1.Domain/Services/LogEntryFactory.cs
+++ b/AiDevTest1.Domain/Services/LogEntryFactory.cs
@@ -1,7 +1,7 @@
-using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Domain.Interfaces;
 using AiDevTest1.Domain.Models;
 
-namespace AiDevTest1.Application.Factories;
+namespace AiDevTest1.Domain.Services;
 
 /// <summary>
 /// LogEntryオブジェクトを生成するファクトリクラス

--- a/AiDevTest1.Infrastructure/Services/LogWriteService.cs
+++ b/AiDevTest1.Infrastructure/Services/LogWriteService.cs
@@ -1,5 +1,6 @@
 using AiDevTest1.Application.Interfaces;
 using AiDevTest1.Application.Models;
+using AiDevTest1.Domain.Interfaces;
 
 namespace AiDevTest1.Infrastructure.Services
 {

--- a/AiDevTest1.Tests/LogEntryFactoryTests.cs
+++ b/AiDevTest1.Tests/LogEntryFactoryTests.cs
@@ -1,4 +1,4 @@
-using AiDevTest1.Application.Factories;
+using AiDevTest1.Domain.Services;
 using AiDevTest1.Domain.Models;
 using Xunit;
 

--- a/AiDevTest1.Tests/LogWriteServiceTests.cs
+++ b/AiDevTest1.Tests/LogWriteServiceTests.cs
@@ -1,6 +1,7 @@
 using AiDevTest1.Application.Interfaces;
 using AiDevTest1.Application.Models;
 using AiDevTest1.Domain.Models;
+using AiDevTest1.Domain.Interfaces;
 using AiDevTest1.Infrastructure.Services;
 using FluentAssertions;
 using Moq;

--- a/AiDevTest1.WpfApp/App.xaml.cs
+++ b/AiDevTest1.WpfApp/App.xaml.cs
@@ -2,6 +2,9 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using AiDevTest1.Application.Interfaces;
+
+using AiDevTest1.Domain.Interfaces;
+using AiDevTest1.Domain.Services;
 using AiDevTest1.Infrastructure.Configuration;
 using AiDevTest1.Infrastructure.Services;
 using AiDevTest1.WpfApp.ViewModels;
@@ -47,7 +50,7 @@ namespace AiDevTest1.WpfApp
       services.Configure<IoTHubConfiguration>(authSection);
 
       // Factories and Handlers
-      services.AddTransient<ILogEntryFactory, AiDevTest1.Application.Factories.LogEntryFactory>();
+      services.AddTransient<ILogEntryFactory, LogEntryFactory>();
       services.AddTransient<ILogFileHandler, LogFileHandler>();
 
       // Services


### PR DESCRIPTION
## 概要
issue #50 に対応し、`LogEntryFactory`クラスをDDDの原則に従ってApplicationレイヤーからDomainレイヤーへ移動しました。

## 変更内容

### 📁 ファイル移動
- **LogEntryFactoryクラス**
  - 移動元: `AiDevTest1.Application/Factories/LogEntryFactory.cs`
  - 移動先: `AiDevTest1.Domain/Services/LogEntryFactory.cs`
- **ILogEntryFactoryインターフェース**
  - 移動元: `AiDevTest1.Application/Interfaces/ILogEntryFactory.cs`
  - 移動先: `AiDevTest1.Domain/Interfaces/ILogEntryFactory.cs`

### 🔧 名前空間とコード修正
- 名前空間を更新: `AiDevTest1.Application.Factories` → `AiDevTest1.Domain.Services`
- 全ての参照箇所を更新してusing文を活用したクリーンなコードに修正
- 空の`AiDevTest1.Application/Factories/`フォルダを削除

### 🏗️ アーキテクチャ改善
- Domain層からApplication層への循環依存を解決
- DDDの依存関係ルール（依存は内側に向かう）に準拠
- ドメイン知識（EventTypeとメッセージの関連）がDomain層で完結

## DDDの観点からの改善点

### ✅ Before (問題点)
- ファクトリがApplication層に配置されていた
- ドメインの知識がApplication層に漏れていた
- 依存関係の方向が不適切

### ✅ After (改善点)
- ファクトリとインターフェースがDomain層に統一配置
- ドメイン知識の凝集度向上
- Domain層が他のレイヤーに依存しない純粋な設計
- EventTypeとメッセージの関連付けがドメイン層で完結

## 📊 テスト結果
- **ビルド**: ✅ 成功（循環依存エラー解決済み）
- **テスト**: ✅ 全318テスト成功（失敗数: 0）

## 📋 変更ファイル一覧
- ✨ 新規作成: `AiDevTest1.Domain/Interfaces/ILogEntryFactory.cs`
- ✨ 新規作成: `AiDevTest1.Domain/Services/LogEntryFactory.cs`
- 🔧 修正: `AiDevTest1.Infrastructure/Services/LogWriteService.cs`
- 🔧 修正: `AiDevTest1.Tests/LogEntryFactoryTests.cs`
- 🔧 修正: `AiDevTest1.Tests/LogWriteServiceTests.cs`
- 🔧 修正: `AiDevTest1.WpfApp/App.xaml.cs`
- 🗑️ 削除: `AiDevTest1.Application/Factories/LogEntryFactory.cs`
- 🗑️ 削除: `AiDevTest1.Application/Interfaces/ILogEntryFactory.cs`

fixes #50