### PR TITLE
feat: Add Terraform infrastructure for Azure IoT Hub and Storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,17 @@ artifacts/
 # Operations Management Suite (OMS) instrumentation key and host entry
 Logging.Mode=VisualStudio
 HockeyAppSampleiOSCrashOnly.sln.ideobjecthistory
+
+# Terraform
+*.tfstate
+*.tfstate.*
+*.tfplan
+*.tfplan.*
+.terraform/
+.terraform.lock.hcl
+crash.log
+
+# Terraform variable files with secrets (keep terraform.tfvars as template)
+.terraform/terraform.tfvars.local
+.terraform/terraform.auto.tfvars
+.terraform/*.auto.tfvars

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,159 @@
+# Azure IoT Hub Infrastructure with Terraform
+
+このディレクトリには、Azure IoT HubとStorage Accountを作成するためのTerraformファイルが含まれています。
+
+## 前提条件
+
+- [Terraform](https://terraform.io/) v1.0以降がインストールされていること
+- [Azure CLI](https://docs.microsoft.com/en-us/cli/azure/) がインストールされ、ログインしていること
+- 適切なAzureサブスクリプションへのアクセス権限があること
+
+## ファイル構成
+
+```txt
+.terraform/
+├── main.tf           # メインのリソース定義
+├── variables.tf      # 変数定義
+├── outputs.tf        # 出力値定義
+├── terraform.tfvars  # 変数の値設定（要設定）
+└── README.md         # このファイル
+```
+
+## セットアップ手順
+
+### 1. Azure CLIでログイン
+
+```bash
+az login
+az account set --subscription "your-subscription-id"
+```
+
+### 2. terraform.tfvarsファイルの編集
+
+`terraform.tfvars`ファイルを開き、環境に応じて値を編集してください：
+
+```hcl
+# Resource Group Configuration
+resource_group_name = "rg-aidevtest1"
+location            = "Japan East"
+environment         = "dev"
+
+# Storage Account Configuration
+storage_account_prefix   = "staidevtest1"     # 3-15文字、英数字のみ
+storage_replication_type = "LRS"
+storage_container_name   = "iot-uploads"
+
+# IoT Hub Configuration
+iothub_prefix       = "iot-aidevtest1"        # 3-40文字
+iothub_sku_name     = "F1"                    # F1(無料), S1, S2, S3
+iothub_sku_capacity = 1
+
+# Device Configuration
+device_id = "test-device-001"                 # 1-128文字
+```
+
+### 3. Terraformの初期化
+
+```bash
+cd .terraform
+terraform init
+```
+
+### 4. 実行計画の確認
+
+```bash
+terraform plan
+```
+
+### 5. リソースの作成
+
+```bash
+terraform apply
+```
+
+確認プロンプトで "yes" を入力してリソースを作成します。
+
+## 作成されるリソース
+
+1. **Resource Group** - すべてのリソースのコンテナ
+2. **Storage Account** - IoT Hubファイルアップロード用（LRS、一意の名前）
+3. **Storage Container** - アップロードファイル保存用コンテナ
+4. **IoT Hub** - デバイス接続とファイルアップロード機能（F1無料プラン）
+5. **IoT Device** - テスト用のデバイス登録
+6. **Shared Access Policy** - デバイス接続用のポリシー
+
+## 出力値の確認
+
+デプロイ後、以下のコマンドで重要な値を確認できます：
+
+```bash
+# すべての出力値を表示
+terraform output
+
+# 特定の出力値を表示（センシティブ値含む）
+terraform output -json
+
+# デバイス接続文字列を表示
+terraform output iothub_device_connection_string
+```
+
+## アプリケーション設定の更新
+
+Terraform実行後、出力されたデバイス接続文字列を`appsettings.json`に設定してください：
+
+```bash
+# 接続文字列を取得
+terraform output -raw iothub_device_connection_string
+
+# デバイスIDを取得
+terraform output -raw device_id
+```
+
+`AiDevTest1.WpfApp/appsettings.json`を以下のように更新：
+
+```json
+{
+  "AuthInfo": {
+    "ConnectionString": "HostName=iot-aidevtest1xxxxxxxx.azure-devices.net;DeviceId=test-device-001;SharedAccessKey=xxxxxxxxxx",
+    "DeviceId": "test-device-001"
+  }
+}
+```
+
+## リソースの削除
+
+**注意**: この操作はすべてのリソースを削除します。データは復旧できません。
+
+```bash
+terraform destroy
+```
+
+## よくある問題と解決方法
+
+### 1. リソース名の競合
+
+Storage AccountやIoT Hubの名前が既に使用されている場合：
+
+- `terraform.tfvars`でプレフィックスを変更してください
+- ランダムサフィックスが自動的に追加されます
+
+### 2. 権限エラー
+
+リソース作成に失敗する場合：
+
+- Azure CLIで適切なサブスクリプションにログインしているか確認
+- Contributorまたは相当の権限があるか確認
+
+### 3. IoT Hub無料プランの制限
+
+F1プランは以下の制限があります：
+
+- 1サブスクリプションあたり1つまで
+- 1日8,000メッセージまで
+- 既にF1 IoT Hubがある場合は、S1プランに変更してください
+
+## 参考リンク
+
+- [Azure IoT Hub価格](https://azure.microsoft.com/ja-jp/pricing/details/iot-hub/)
+- [Azure Storage価格](https://azure.microsoft.com/ja-jp/pricing/details/storage/)
+- [Terraform Azure Provider](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -11,7 +11,7 @@
 ## ファイル構成
 
 ```txt
-.terraform/
+terraform/
 ├── main.tf           # メインのリソース定義
 ├── variables.tf      # 変数定義
 ├── outputs.tf        # 出力値定義
@@ -55,7 +55,7 @@ device_id = "test-device-001"                 # 1-128文字
 ### 3. Terraformの初期化
 
 ```bash
-cd .terraform
+cd terraform
 terraform init
 ```
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,117 @@
+# Configure the Azure Provider
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~>3.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~>3.4"
+    }
+  }
+}
+
+# Configure the Microsoft Azure Provider
+provider "azurerm" {
+  features {}
+}
+
+# Generate random suffix for unique resource names
+resource "random_string" "suffix" {
+  length  = 8
+  special = false
+  upper   = false
+}
+
+# Create a resource group
+resource "azurerm_resource_group" "main" {
+  name     = var.resource_group_name
+  location = var.location
+
+  tags = {
+    Environment = var.environment
+    Project     = "AiDevTest1"
+    ManagedBy   = "Terraform"
+  }
+}
+
+# Create a storage account for IoT Hub file uploads
+resource "azurerm_storage_account" "iot_storage" {
+  name                     = "${var.storage_account_prefix}${random_string.suffix.result}"
+  resource_group_name      = azurerm_resource_group.main.name
+  location                 = azurerm_resource_group.main.location
+  account_tier             = "Standard"
+  account_replication_type = var.storage_replication_type
+
+  # Enable blob storage features needed for IoT Hub
+  blob_properties {
+    cors_rule {
+      allowed_headers    = ["*"]
+      allowed_methods    = ["DELETE", "GET", "HEAD", "MERGE", "POST", "OPTIONS", "PUT"]
+      allowed_origins    = ["*"]
+      exposed_headers    = ["*"]
+      max_age_in_seconds = 3600
+    }
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = "AiDevTest1"
+    ManagedBy   = "Terraform"
+    Purpose     = "IoTHubFileStorage"
+  }
+}
+
+# Create a storage container for uploaded files
+resource "azurerm_storage_container" "iot_files" {
+  name                  = var.storage_container_name
+  storage_account_id    = azurerm_storage_account.iot_storage.id
+  container_access_type = "private"
+}
+
+# Create IoT Hub
+resource "azurerm_iothub" "main" {
+  name                = "${var.iothub_prefix}${random_string.suffix.result}"
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+
+  sku {
+    name     = var.iothub_sku_name
+    capacity = var.iothub_sku_capacity
+  }
+
+  # Configure file upload settings
+  file_upload {
+    connection_string = azurerm_storage_account.iot_storage.primary_blob_connection_string
+    container_name    = azurerm_storage_container.iot_files.name
+    sas_ttl           = "PT1H"
+
+    lock_duration      = "PT1M"
+    default_ttl        = "PT1H"
+    max_delivery_count = 10
+  }
+
+  tags = {
+    Environment = var.environment
+    Project     = "AiDevTest1"
+    ManagedBy   = "Terraform"
+  }
+}
+
+# Create IoT Hub shared access policy for devices
+resource "azurerm_iothub_shared_access_policy" "device_connect" {
+  name                = "device-connect"
+  resource_group_name = azurerm_resource_group.main.name
+  iothub_name         = azurerm_iothub.main.name
+
+  device_connect = true
+}
+
+# Create an IoT device
+resource "azurerm_iothub_device" "test_device" {
+  name                = var.device_id
+  iothub_name         = azurerm_iothub.main.name
+  resource_group_name = azurerm_resource_group.main.name
+  authentication_type = "sas"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,78 @@
+# Output values for Azure IoT Hub infrastructure
+
+output "resource_group_name" {
+  description = "Name of the resource group"
+  value       = azurerm_resource_group.main.name
+}
+
+output "resource_group_location" {
+  description = "Location of the resource group"
+  value       = azurerm_resource_group.main.location
+}
+
+output "storage_account_name" {
+  description = "Name of the storage account"
+  value       = azurerm_storage_account.iot_storage.name
+}
+
+output "storage_account_primary_connection_string" {
+  description = "Primary connection string for the storage account"
+  value       = azurerm_storage_account.iot_storage.primary_connection_string
+  sensitive   = true
+}
+
+output "storage_container_name" {
+  description = "Name of the storage container"
+  value       = azurerm_storage_container.iot_files.name
+}
+
+output "iothub_name" {
+  description = "Name of the IoT Hub"
+  value       = azurerm_iothub.main.name
+}
+
+output "iothub_hostname" {
+  description = "Hostname of the IoT Hub"
+  value       = azurerm_iothub.main.hostname
+}
+
+output "iothub_device_connection_string" {
+  description = "Connection string for the IoT device"
+  value       = "HostName=${azurerm_iothub.main.hostname};DeviceId=${azurerm_iothub_device.test_device.name};SharedAccessKey=${azurerm_iothub_device.test_device.primary_key}"
+  sensitive   = true
+}
+
+output "iothub_service_connection_string" {
+  description = "Service connection string for the IoT Hub (for management operations)"
+  value       = "HostName=${azurerm_iothub.main.hostname};SharedAccessKeyName=${azurerm_iothub_shared_access_policy.device_connect.name};SharedAccessKey=${azurerm_iothub_shared_access_policy.device_connect.primary_key}"
+  sensitive   = true
+}
+
+output "device_id" {
+  description = "IoT device ID"
+  value       = azurerm_iothub_device.test_device.name
+}
+
+output "device_primary_key" {
+  description = "Primary key for the IoT device"
+  value       = azurerm_iothub_device.test_device.primary_key
+  sensitive   = true
+}
+
+output "device_secondary_key" {
+  description = "Secondary key for the IoT device"
+  value       = azurerm_iothub_device.test_device.secondary_key
+  sensitive   = true
+}
+
+# Configuration for appsettings.json
+output "appsettings_configuration" {
+  description = "Configuration values for appsettings.json"
+  value = {
+    AuthInfo = {
+      ConnectionString = "HostName=${azurerm_iothub.main.hostname};DeviceId=${azurerm_iothub_device.test_device.name};SharedAccessKey=${azurerm_iothub_device.test_device.primary_key}"
+      DeviceId         = azurerm_iothub_device.test_device.name
+    }
+  }
+  sensitive = true
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,7 +17,7 @@ output "storage_account_name" {
 
 output "storage_account_primary_connection_string" {
   description = "Primary connection string for the storage account"
-  value       = azurerm_storage_account.iot_storage.primary_connection_string
+  value       = azurerm_storage_account.iot_storage.primary_blob_connection_string
   sensitive   = true
 }
 

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,0 +1,20 @@
+# Terraform variables configuration for Azure IoT Hub infrastructure
+# Copy this file and modify values as needed for your environment
+
+# Resource Group Configuration
+resource_group_name = "rg-aidevtest1"
+location            = "Japan East"
+environment         = "dev"
+
+# Storage Account Configuration
+storage_account_prefix   = "staidevtest1"
+storage_replication_type = "LRS"
+storage_container_name   = "iot-uploads"
+
+# IoT Hub Configuration
+iothub_prefix       = "iot-aidevtest1"
+iothub_sku_name     = "F1" # F1 is free tier, S1/S2/S3 are paid tiers
+iothub_sku_capacity = 1
+
+# Device Configuration
+device_id = "test-device-001"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,91 @@
+# Variable definitions for Azure IoT Hub infrastructure
+
+variable "resource_group_name" {
+  description = "Name of the resource group"
+  type        = string
+  default     = "rg-aidevtest1"
+}
+
+variable "location" {
+  description = "Azure region for resources"
+  type        = string
+  default     = "Japan East"
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "storage_account_prefix" {
+  description = "Prefix for storage account name (random suffix will be added)"
+  type        = string
+  default     = "staidevtest1"
+
+  validation {
+    condition     = can(regex("^[a-z0-9]{3,15}$", var.storage_account_prefix))
+    error_message = "Storage account prefix must be 3-15 characters long and contain only lowercase letters and numbers."
+  }
+}
+
+variable "storage_replication_type" {
+  description = "Storage account replication type"
+  type        = string
+  default     = "LRS"
+
+  validation {
+    condition     = contains(["LRS", "GRS", "RAGRS", "ZRS", "GZRS", "RAGZRS"], var.storage_replication_type)
+    error_message = "Storage replication type must be one of: LRS, GRS, RAGRS, ZRS, GZRS, RAGZRS."
+  }
+}
+
+variable "storage_container_name" {
+  description = "Name of the storage container for IoT Hub file uploads"
+  type        = string
+  default     = "iot-uploads"
+}
+
+variable "iothub_prefix" {
+  description = "Prefix for IoT Hub name (random suffix will be added)"
+  type        = string
+  default     = "iot-aidevtest1"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]{3,40}$", var.iothub_prefix))
+    error_message = "IoT Hub prefix must be 3-40 characters long and contain only letters, numbers, and hyphens."
+  }
+}
+
+variable "iothub_sku_name" {
+  description = "IoT Hub SKU name"
+  type        = string
+  default     = "F1"
+
+  validation {
+    condition     = contains(["F1", "S1", "S2", "S3"], var.iothub_sku_name)
+    error_message = "IoT Hub SKU must be one of: F1 (free), S1, S2, S3."
+  }
+}
+
+variable "iothub_sku_capacity" {
+  description = "IoT Hub SKU capacity (number of units)"
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.iothub_sku_capacity >= 1 && var.iothub_sku_capacity <= 200
+    error_message = "IoT Hub SKU capacity must be between 1 and 200."
+  }
+}
+
+variable "device_id" {
+  description = "IoT device ID"
+  type        = string
+  default     = "test-device-001"
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-._]{1,128}$", var.device_id))
+    error_message = "Device ID must be 1-128 characters long and contain only letters, numbers, hyphens, periods, and underscores."
+  }
+}


### PR DESCRIPTION
## 概要

Azure IoT HubとStorage AccountをTerraformで作成するための実装を追加しました。

## 追加されたファイル

- `terraform/main.tf` - メインのリソース定義
- `terraform/variables.tf` - 変数定義（バリデーション付き）
- `terraform/outputs.tf` - 出力値定義（接続文字列など）
- `terraform/terraform.tfvars` - デフォルト値設定
- `terraform/README.md` - セットアップと使用方法
- `.gitignore` - Terraformファイルの除外設定

## 作成されるリソース

1. **Resource Group** - すべてのリソースのコンテナ
2. **Storage Account** - IoT Hubファイルアップロード用（LRS、一意の名前）
3. **Storage Container** - アップロードファイル保存用コンテナ
4. **IoT Hub** - デバイス接続とファイルアップロード機能（F1無料プラン）
5. **IoT Device** - テスト用のデバイス登録
6. **Shared Access Policy** - デバイス接続用のポリシー

## 主な特徴

- ✅ 設定可能: すべてのリソース名、リージョン、SKUが変数で設定可能
- ✅ 一意性確保: ランダムサフィックスで名前の競合を回避
- ✅ セキュア: センシティブな接続文字列は適切にマーク
- ✅ ベストプラクティス: 公式ドキュメントに従った構成
- ✅ 開発向け: F1無料プランをデフォルトに設定
- ✅ 最新対応: Azure Provider v3.0+で非推奨属性を修正済み

## 使用方法

```bash
cd terraform
terraform init
terraform plan
terraform apply
```

詳細な手順は `terraform/README.md` を参照してください。

## テスト環境での確認事項

- [ ] `terraform plan` でエラーがないことを確認
- [ ] リソース作成後、出力された接続文字列をappsettings.jsonに設定
- [ ] アプリケーションからIoT Hubへの接続を確認
- [ ] ファイルアップロード機能の動作確認

## Breaking Changes

なし（新規追加のみ）