### PR TITLE
fix: Terraformの設定エラーを修正

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,7 +66,7 @@ resource "azurerm_storage_account" "iot_storage" {
 # Create a storage container for uploaded files
 resource "azurerm_storage_container" "iot_files" {
   name                  = var.storage_container_name
-  storage_account_id    = azurerm_storage_account.iot_storage.id
+  storage_account_name  = azurerm_storage_account.iot_storage.name
   container_access_type = "private"
 }
 
@@ -108,10 +108,5 @@ resource "azurerm_iothub_shared_access_policy" "device_connect" {
   device_connect = true
 }
 
-# Create an IoT device
-resource "azurerm_iothub_device" "test_device" {
-  name                = var.device_id
-  iothub_name         = azurerm_iothub.main.name
-  resource_group_name = azurerm_resource_group.main.name
-  authentication_type = "sas"
-}
+# Note: IoT Hub devices are typically created programmatically through the IoT Hub SDK
+# or Azure CLI rather than through Terraform resources

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -36,43 +36,18 @@ output "iothub_hostname" {
   value       = azurerm_iothub.main.hostname
 }
 
-output "iothub_device_connection_string" {
-  description = "Connection string for the IoT device"
-  value       = "HostName=${azurerm_iothub.main.hostname};DeviceId=${azurerm_iothub_device.test_device.name};SharedAccessKey=${azurerm_iothub_device.test_device.primary_key}"
-  sensitive   = true
-}
-
 output "iothub_service_connection_string" {
   description = "Service connection string for the IoT Hub (for management operations)"
   value       = "HostName=${azurerm_iothub.main.hostname};SharedAccessKeyName=${azurerm_iothub_shared_access_policy.device_connect.name};SharedAccessKey=${azurerm_iothub_shared_access_policy.device_connect.primary_key}"
   sensitive   = true
 }
 
-output "device_id" {
-  description = "IoT device ID"
-  value       = azurerm_iothub_device.test_device.name
-}
+# Note: Device-specific outputs have been removed since azurerm_iothub_device
+# resource is not supported in Terraform. Create devices programmatically using:
+# - Azure CLI: az iot hub device-identity create
+# - Azure IoT SDK
+# - Azure Portal
 
-output "device_primary_key" {
-  description = "Primary key for the IoT device"
-  value       = azurerm_iothub_device.test_device.primary_key
-  sensitive   = true
-}
-
-output "device_secondary_key" {
-  description = "Secondary key for the IoT device"
-  value       = azurerm_iothub_device.test_device.secondary_key
-  sensitive   = true
-}
-
-# Configuration for appsettings.json
-output "appsettings_configuration" {
-  description = "Configuration values for appsettings.json"
-  value = {
-    AuthInfo = {
-      ConnectionString = "HostName=${azurerm_iothub.main.hostname};DeviceId=${azurerm_iothub_device.test_device.name};SharedAccessKey=${azurerm_iothub_device.test_device.primary_key}"
-      DeviceId         = azurerm_iothub_device.test_device.name
-    }
-  }
-  sensitive = true
-}
+# Example commands to create a device after deployment:
+# az iot hub device-identity create --hub-name <iothub_name> --device-id <device_id>
+# az iot hub device-identity connection-string show --hub-name <iothub_name> --device-id <device_id>


### PR DESCRIPTION
## 概要
Terraformの実行時に発生していたエラーを修正しました。

## 修正内容

### 1. azurerm_storage_containerの設定エラー修正
- `storage_account_id` パラメータが正しくないため、`storage_account_name` に変更
- Azure Terraform プロバイダーの仕様に準拠

### 2. サポートされていないリソースタイプの削除
- `azurerm_iothub_device` リソースタイプはAzure Terraform プロバイダーでサポートされていないため削除
- main.tf と outputs.tf の両方から関連する設定を除去

### 3. outputs.tfの修正
- 削除されたリソースへの参照を除去
- IoTデバイスを手動で作成する方法のコメントを追加

## 検証結果

```bash
terraform validate
# Success! The configuration is valid.

terraform plan
# Plan: 6 to add, 0 to change, 0 to destroy.
```

## IoTデバイスの作成について

TerraformではIoTデバイスを直接作成できないため、インフラ構築後に以下の方法で手動作成が必要です：

```bash
# Azure CLIでのデバイス作成
az iot hub device-identity create --hub-name <iothub_name> --device-id <device_id>
az iot hub device-identity connection-string show --hub-name <iothub_name> --device-id <device_id>
```

## 作成されるリソース

- Resource Group
- Storage Account (ファイルアップロード用)
- Storage Container
- IoT Hub
- IoT Hub共有アクセスポリシー
- ランダム文字列（一意性確保）

## テスト

- [x] terraform validate
- [x] terraform plan
- [x] 設定ファイルの構文チェック