### PR TITLE
fix: BlobパスからデバイスIDを除去してログファイルパスを修正

### DIFF
--- a/AiDevTest1.Infrastructure/Services/IoTHubClient.cs
+++ b/AiDevTest1.Infrastructure/Services/IoTHubClient.cs
@@ -66,8 +66,8 @@ public class IoTHubClient : IIoTHubClient, IDisposable
 
     try
     {
-      // デバイスID/ファイル名の形式でBlob名を構築
-      var fullBlobName = blobName.GetFullBlobName(_deviceId);
+      // Blob名をそのまま使用（デバイスIDは含めない）
+      var fullBlobName = blobName.Value;
 
       // Azure IoT Hub SDKを使用してファイルアップロード用のSAS URIを取得
       var fileUploadSasUriRequest = new FileUploadSasUriRequest

--- a/AiDevTest1.Tests/IoTHubClientTests.cs
+++ b/AiDevTest1.Tests/IoTHubClientTests.cs
@@ -372,10 +372,10 @@ public class IoTHubClientTests
   }
 
   /// <summary>
-  /// blobNameにデバイスIDが適切に含まれることをテスト（SAS URI生成時のfullBlobName構築）
+  /// 有効なBlobNameでSAS URI取得を試行した際の動作をテスト（実際の接続なしで失敗することを確認）
   /// </summary>
   [Fact]
-  public async Task GetFileUploadSasUriAsync_WithValidBlobName_IncludesDeviceIdInBlobName()
+  public async Task GetFileUploadSasUriAsync_WithValidBlobName_ReturnsFailureWithoutConnection()
   {
     // Arrange
     var deviceId = new DeviceId("test-device-123");


### PR DESCRIPTION
## 概要
ログファイルのアップロードパスに余分な`default-device`ディレクトリが含まれる問題を修正しました。

## 問題
- 現在のパス: `mydevice-20250531/default-device/2025-05-31.log`
- 期待されるパス: `mydevice-20250531/2025-05-31.log`

## 原因
`IoTHubClient.GetFileUploadSasUriAsync`メソッドで`blobName.GetFullBlobName(_deviceId)`を使用していたため、デバイスID（"default-device"）がパスに含まれていました。

## 修正内容
- `IoTHubClient.cs`: `blobName.GetFullBlobName(_deviceId)` → `blobName.Value`に変更
- 関連するコメントを実態に合わせて更新
- テストのメソッド名とコメントを実態に合わせて更新

## 動作確認
- 全37件のテストが成功
- 他の機能に影響がないことを確認済み

## 変更ファイル
- `AiDevTest1.Infrastructure/Services/IoTHubClient.cs`
- `AiDevTest1.Tests/IoTHubClientTests.cs`