### PR TITLE
fix: IRetryPolicy依存性注入の設定を追加

### DIFF
--- a/AiDevTest1.WpfApp/App.xaml.cs
+++ b/AiDevTest1.WpfApp/App.xaml.cs
@@ -2,10 +2,10 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using AiDevTest1.Application.Interfaces;
-
 using AiDevTest1.Domain.Interfaces;
 using AiDevTest1.Domain.Services;
 using AiDevTest1.Infrastructure.Configuration;
+using AiDevTest1.Infrastructure.Policies;
 using AiDevTest1.Infrastructure.Services;
 using AiDevTest1.WpfApp.ViewModels;
 using Microsoft.Extensions.Logging; // Kept for ILogger if used by Host.CreateDefaultBuilder or future use
@@ -52,6 +52,9 @@ namespace AiDevTest1.WpfApp
       // Factories and Handlers
       services.AddTransient<ILogEntryFactory, LogEntryFactory>();
       services.AddTransient<ILogFileHandler, LogFileHandler>();
+
+      // Policies
+      services.AddTransient<IRetryPolicy, ExponentialBackoffRetryPolicy>();
 
       // Services
       services.AddSingleton<ILogWriteService, LogWriteService>();


### PR DESCRIPTION
## 概要
アプリケーション起動時に発生していた依存性注入エラーを修正しました。

## 問題
- `FileUploadService`の起動時に`IRetryPolicy`サービスを解決できないエラーが発生
- エラーメッセージ: "Unable to resolve service for type 'AiDevTest1.Application.Interfaces.IRetryPolicy'"

## 修正内容
- `App.xaml.cs`の`ConfigureServices`メソッドに`IRetryPolicy`の実装クラス`ExponentialBackoffRetryPolicy`の登録を追加
- `AiDevTest1.Infrastructure.Policies`のusingステートメントを追加

## 変更ファイル
- `AiDevTest1.WpfApp/App.xaml.cs`

## テスト
- アプリケーションが正常に起動することを確認
- 依存性注入エラーが解決されることを確認

## レビューポイント
- 依存性注入の登録が適切に行われているか
- ライフタイム管理（Transient）が適切か