### PR TITLE
feat: ログ書き込みコマンドパターンの実装 (#70)

### DIFF
--- a/AiDevTest1.Application/Commands/WriteLogCommand.cs
+++ b/AiDevTest1.Application/Commands/WriteLogCommand.cs
@@ -1,0 +1,13 @@
+using AiDevTest1.Application.Interfaces;
+
+namespace AiDevTest1.Application.Commands
+{
+    /// <summary>
+    /// ログエントリの書き込みを指示するコマンド
+    /// </summary>
+    public class WriteLogCommand : ICommand
+    {
+        // 現時点では追加のプロパティは不要
+        // 将来的にはEventTypeやメッセージなどを受け取る可能性あり
+    }
+}

--- a/AiDevTest1.Application/Handlers/WriteLogCommandHandler.cs
+++ b/AiDevTest1.Application/Handlers/WriteLogCommandHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDevTest1.Application.Commands;
+using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Application.Models;
+
+namespace AiDevTest1.Application.Handlers
+{
+    /// <summary>
+    /// WriteLogCommandの処理を実行するハンドラー
+    /// </summary>
+    public class WriteLogCommandHandler : ICommandHandler<WriteLogCommand>
+    {
+        private readonly ILogWriteService _logWriteService;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="logWriteService">ログ書き込みサービス</param>
+        public WriteLogCommandHandler(ILogWriteService logWriteService)
+        {
+            _logWriteService = logWriteService ?? throw new ArgumentNullException(nameof(logWriteService));
+        }
+
+        /// <summary>
+        /// コマンドの処理を非同期で実行します
+        /// </summary>
+        /// <param name="command">実行するコマンド</param>
+        /// <param name="cancellationToken">キャンセレーショントークン</param>
+        /// <returns>処理結果</returns>
+        public async Task<Result> HandleAsync(WriteLogCommand command, CancellationToken cancellationToken = default)
+        {
+            if (command == null)
+            {
+                return Result.Failure("コマンドがnullです。");
+            }
+
+            try
+            {
+                // ログ書き込みサービスを使用してログエントリを書き込む
+                return await _logWriteService.WriteLogEntryAsync();
+            }
+            catch (Exception ex)
+            {
+                // 予期しない例外をキャッチしてResult.Failureとして返す
+                return Result.Failure($"ログの書き込み中にエラーが発生しました: {ex.Message}");
+            }
+        }
+    }
+}

--- a/AiDevTest1.Tests/Handlers/WriteLogCommandHandlerTests.cs
+++ b/AiDevTest1.Tests/Handlers/WriteLogCommandHandlerTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDevTest1.Application.Commands;
+using AiDevTest1.Application.Handlers;
+using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Application.Models;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace AiDevTest1.Tests.Handlers
+{
+    public class WriteLogCommandHandlerTests
+    {
+        private readonly Mock<ILogWriteService> _mockLogWriteService;
+        private readonly WriteLogCommandHandler _handler;
+
+        public WriteLogCommandHandlerTests()
+        {
+            _mockLogWriteService = new Mock<ILogWriteService>();
+            _handler = new WriteLogCommandHandler(_mockLogWriteService.Object);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithValidCommand_ShouldReturnSuccessResult()
+        {
+            // Arrange
+            var command = new WriteLogCommand();
+            var expectedResult = Result.Success();
+            _mockLogWriteService.Setup(x => x.WriteLogEntryAsync())
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _handler.HandleAsync(command);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            _mockLogWriteService.Verify(x => x.WriteLogEntryAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithNullCommand_ShouldReturnFailureResult()
+        {
+            // Arrange
+            WriteLogCommand nullCommand = null;
+
+            // Act
+            var result = await _handler.HandleAsync(nullCommand);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Be("コマンドがnullです。");
+            _mockLogWriteService.Verify(x => x.WriteLogEntryAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenLogWriteServiceFails_ShouldReturnFailureResult()
+        {
+            // Arrange
+            var command = new WriteLogCommand();
+            var expectedErrorMessage = "ログファイルへの書き込みに失敗しました";
+            var expectedResult = Result.Failure(expectedErrorMessage);
+            _mockLogWriteService.Setup(x => x.WriteLogEntryAsync())
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _handler.HandleAsync(command);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Be(expectedErrorMessage);
+            _mockLogWriteService.Verify(x => x.WriteLogEntryAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenLogWriteServiceThrowsException_ShouldReturnFailureResult()
+        {
+            // Arrange
+            var command = new WriteLogCommand();
+            var exceptionMessage = "Test exception";
+            _mockLogWriteService.Setup(x => x.WriteLogEntryAsync())
+                .ThrowsAsync(new Exception(exceptionMessage));
+
+            // Act
+            var result = await _handler.HandleAsync(command);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Contain(exceptionMessage);
+            _mockLogWriteService.Verify(x => x.WriteLogEntryAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithCancellationToken_ShouldPassTokenToService()
+        {
+            // Arrange
+            var command = new WriteLogCommand();
+            var cancellationToken = new CancellationToken();
+            var expectedResult = Result.Success();
+            _mockLogWriteService.Setup(x => x.WriteLogEntryAsync())
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _handler.HandleAsync(command, cancellationToken);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            _mockLogWriteService.Verify(x => x.WriteLogEntryAsync(), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_WithNullLogWriteService_ShouldThrowArgumentNullException()
+        {
+            // Act & Assert
+            var action = () => new WriteLogCommandHandler(null);
+            action.Should().Throw<ArgumentNullException>()
+                .WithParameterName("logWriteService");
+        }
+    }
+}

--- a/AiDevTest1.WpfApp/App.xaml.cs
+++ b/AiDevTest1.WpfApp/App.xaml.cs
@@ -2,6 +2,8 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Application.Commands;
+using AiDevTest1.Application.Handlers;
 using AiDevTest1.Domain.Interfaces;
 using AiDevTest1.Domain.Services;
 using AiDevTest1.Infrastructure.Configuration;
@@ -52,6 +54,9 @@ namespace AiDevTest1.WpfApp
       // Factories and Handlers
       services.AddTransient<ILogEntryFactory, LogEntryFactory>();
       services.AddTransient<ILogFileHandler, LogFileHandler>();
+
+      // Command Handlers
+      services.AddTransient<ICommandHandler<WriteLogCommand>, WriteLogCommandHandler>();
 
       // Policies
       services.AddTransient<IRetryPolicy, ExponentialBackoffRetryPolicy>();

--- a/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
+++ b/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Application.Commands;
 using AiDevTest1.WpfApp.Helpers;
 using System;
 using System.Threading.Tasks;
@@ -13,7 +14,7 @@ namespace AiDevTest1.WpfApp.ViewModels
   /// </summary>
   public partial class MainWindowViewModel : ObservableObject
   {
-    private readonly ILogWriteService _logWriteService;
+    private readonly ICommandHandler<WriteLogCommand> _writeLogCommandHandler;
     private readonly IFileUploadService _fileUploadService;
 
     /// <summary>
@@ -30,11 +31,11 @@ namespace AiDevTest1.WpfApp.ViewModels
     /// <summary>
     /// コンストラクタ（依存性注入）
     /// </summary>
-    /// <param name="logWriteService">ログ書き込みサービス</param>
+    /// <param name="writeLogCommandHandler">ログ書き込みコマンドハンドラー</param>
     /// <param name="fileUploadService">ファイルアップロードサービス</param>
-    public MainWindowViewModel(ILogWriteService logWriteService, IFileUploadService fileUploadService)
+    public MainWindowViewModel(ICommandHandler<WriteLogCommand> writeLogCommandHandler, IFileUploadService fileUploadService)
     {
-      _logWriteService = logWriteService ?? throw new ArgumentNullException(nameof(logWriteService));
+      _writeLogCommandHandler = writeLogCommandHandler ?? throw new ArgumentNullException(nameof(writeLogCommandHandler));
       _fileUploadService = fileUploadService ?? throw new ArgumentNullException(nameof(fileUploadService));
 
       // ログ書き込みコマンドの初期化
@@ -65,8 +66,9 @@ namespace AiDevTest1.WpfApp.ViewModels
         // コマンドの実行可否状態を更新
         LogWriteCommand.NotifyCanExecuteChanged();
 
-        // ログエントリの書き込み実行
-        var result = await _logWriteService.WriteLogEntryAsync();
+        // コマンドパターンを使用してログエントリの書き込みを実行
+        var command = new WriteLogCommand();
+        var result = await _writeLogCommandHandler.HandleAsync(command);
 
         // NOTE: issue #18では IDialogService のDI注入が仕様とされていたが、
         // issue #13のDialogService実装が未完了のため、暫定的に既存のDialogHelperを直接使用


### PR DESCRIPTION
## Summary
- Issue #70 に対応し、ログ書き込み処理にコマンドパターンを実装しました
- `ILogWriteService` の直接利用から `ICommandHandler<WriteLogCommand>` パターンへ移行

## Test plan
- [x] WriteLogCommandHandlerの単体テストを実装
- [x] 正常系・異常系のテストケースを網羅
- [x] MainWindowViewModelからコマンドハンドラー経由でログ書き込みが実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)