### PR TITLE
feat: ファイルアップロードコマンドパターンの実装 (#71)

### DIFF
--- a/AiDevTest1.Application/Commands/UploadFileCommand.cs
+++ b/AiDevTest1.Application/Commands/UploadFileCommand.cs
@@ -1,0 +1,13 @@
+using AiDevTest1.Application.Interfaces;
+
+namespace AiDevTest1.Application.Commands
+{
+    /// <summary>
+    /// ファイルアップロードを指示するコマンド
+    /// </summary>
+    public class UploadFileCommand : ICommand
+    {
+        // 現時点では追加のプロパティは不要
+        // 将来的にはファイルパスや対象ファイルの指定などを受け取る可能性あり
+    }
+}

--- a/AiDevTest1.Application/Handlers/UploadFileCommandHandler.cs
+++ b/AiDevTest1.Application/Handlers/UploadFileCommandHandler.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDevTest1.Application.Commands;
+using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Application.Models;
+
+namespace AiDevTest1.Application.Handlers
+{
+    /// <summary>
+    /// UploadFileCommandの処理を実行するハンドラー
+    /// </summary>
+    public class UploadFileCommandHandler : ICommandHandler<UploadFileCommand>
+    {
+        private readonly IFileUploadService _fileUploadService;
+
+        /// <summary>
+        /// コンストラクタ
+        /// </summary>
+        /// <param name="fileUploadService">ファイルアップロードサービス</param>
+        public UploadFileCommandHandler(IFileUploadService fileUploadService)
+        {
+            _fileUploadService = fileUploadService ?? throw new ArgumentNullException(nameof(fileUploadService));
+        }
+
+        /// <summary>
+        /// コマンドの処理を非同期で実行します
+        /// </summary>
+        /// <param name="command">実行するコマンド</param>
+        /// <param name="cancellationToken">キャンセレーショントークン</param>
+        /// <returns>処理結果</returns>
+        public async Task<Result> HandleAsync(UploadFileCommand command, CancellationToken cancellationToken = default)
+        {
+            if (command == null)
+            {
+                return Result.Failure("コマンドがnullです。");
+            }
+
+            try
+            {
+                // ファイルアップロードサービスを使用してログファイルをアップロード
+                return await _fileUploadService.UploadLogFileAsync();
+            }
+            catch (Exception ex)
+            {
+                // 予期しない例外をキャッチしてResult.Failureとして返す
+                return Result.Failure($"ファイルアップロード中にエラーが発生しました: {ex.Message}");
+            }
+        }
+    }
+}

--- a/AiDevTest1.Tests/Handlers/UploadFileCommandHandlerTests.cs
+++ b/AiDevTest1.Tests/Handlers/UploadFileCommandHandlerTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AiDevTest1.Application.Commands;
+using AiDevTest1.Application.Handlers;
+using AiDevTest1.Application.Interfaces;
+using AiDevTest1.Application.Models;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace AiDevTest1.Tests.Handlers
+{
+    public class UploadFileCommandHandlerTests
+    {
+        private readonly Mock<IFileUploadService> _mockFileUploadService;
+        private readonly UploadFileCommandHandler _handler;
+
+        public UploadFileCommandHandlerTests()
+        {
+            _mockFileUploadService = new Mock<IFileUploadService>();
+            _handler = new UploadFileCommandHandler(_mockFileUploadService.Object);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithValidCommand_ShouldReturnSuccessResult()
+        {
+            // Arrange
+            var command = new UploadFileCommand();
+            var expectedResult = Result.Success();
+            _mockFileUploadService.Setup(x => x.UploadLogFileAsync())
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _handler.HandleAsync(command);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            _mockFileUploadService.Verify(x => x.UploadLogFileAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithNullCommand_ShouldReturnFailureResult()
+        {
+            // Arrange
+            UploadFileCommand nullCommand = null;
+
+            // Act
+            var result = await _handler.HandleAsync(nullCommand);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Be("コマンドがnullです。");
+            _mockFileUploadService.Verify(x => x.UploadLogFileAsync(), Times.Never);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenFileUploadServiceFails_ShouldReturnFailureResult()
+        {
+            // Arrange
+            var command = new UploadFileCommand();
+            var expectedErrorMessage = "ファイルアップロードに失敗しました";
+            var expectedResult = Result.Failure(expectedErrorMessage);
+            _mockFileUploadService.Setup(x => x.UploadLogFileAsync())
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _handler.HandleAsync(command);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Be(expectedErrorMessage);
+            _mockFileUploadService.Verify(x => x.UploadLogFileAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WhenFileUploadServiceThrowsException_ShouldReturnFailureResult()
+        {
+            // Arrange
+            var command = new UploadFileCommand();
+            var exceptionMessage = "Test exception";
+            _mockFileUploadService.Setup(x => x.UploadLogFileAsync())
+                .ThrowsAsync(new Exception(exceptionMessage));
+
+            // Act
+            var result = await _handler.HandleAsync(command);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeFalse();
+            result.ErrorMessage.Should().Contain(exceptionMessage);
+            _mockFileUploadService.Verify(x => x.UploadLogFileAsync(), Times.Once);
+        }
+
+        [Fact]
+        public async Task HandleAsync_WithCancellationToken_ShouldPassTokenToService()
+        {
+            // Arrange
+            var command = new UploadFileCommand();
+            var cancellationToken = new CancellationToken();
+            var expectedResult = Result.Success();
+            _mockFileUploadService.Setup(x => x.UploadLogFileAsync())
+                .ReturnsAsync(expectedResult);
+
+            // Act
+            var result = await _handler.HandleAsync(command, cancellationToken);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.IsSuccess.Should().BeTrue();
+            _mockFileUploadService.Verify(x => x.UploadLogFileAsync(), Times.Once);
+        }
+
+        [Fact]
+        public void Constructor_WithNullFileUploadService_ShouldThrowArgumentNullException()
+        {
+            // Act & Assert
+            var action = () => new UploadFileCommandHandler(null);
+            action.Should().Throw<ArgumentNullException>()
+                .WithParameterName("fileUploadService");
+        }
+    }
+}

--- a/AiDevTest1.WpfApp/App.xaml.cs
+++ b/AiDevTest1.WpfApp/App.xaml.cs
@@ -58,6 +58,7 @@ namespace AiDevTest1.WpfApp
 
       // Command Handlers
       services.AddTransient<ICommandHandler<WriteLogCommand>, WriteLogCommandHandler>();
+      services.AddTransient<ICommandHandler<UploadFileCommand>, UploadFileCommandHandler>();
 
       // Policies
       services.AddTransient<IRetryPolicy, ExponentialBackoffRetryPolicy>();

--- a/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
+++ b/AiDevTest1.WpfApp/ViewModels/MainWindowViewModel.cs
@@ -15,7 +15,7 @@ namespace AiDevTest1.WpfApp.ViewModels
   public partial class MainWindowViewModel : ObservableObject
   {
     private readonly ICommandHandler<WriteLogCommand> _writeLogCommandHandler;
-    private readonly IFileUploadService _fileUploadService;
+    private readonly ICommandHandler<UploadFileCommand> _uploadFileCommandHandler;
 
     /// <summary>
     /// 処理実行中かどうかを示すフラグ
@@ -32,11 +32,11 @@ namespace AiDevTest1.WpfApp.ViewModels
     /// コンストラクタ（依存性注入）
     /// </summary>
     /// <param name="writeLogCommandHandler">ログ書き込みコマンドハンドラー</param>
-    /// <param name="fileUploadService">ファイルアップロードサービス</param>
-    public MainWindowViewModel(ICommandHandler<WriteLogCommand> writeLogCommandHandler, IFileUploadService fileUploadService)
+    /// <param name="uploadFileCommandHandler">ファイルアップロードコマンドハンドラー</param>
+    public MainWindowViewModel(ICommandHandler<WriteLogCommand> writeLogCommandHandler, ICommandHandler<UploadFileCommand> uploadFileCommandHandler)
     {
       _writeLogCommandHandler = writeLogCommandHandler ?? throw new ArgumentNullException(nameof(writeLogCommandHandler));
-      _fileUploadService = fileUploadService ?? throw new ArgumentNullException(nameof(fileUploadService));
+      _uploadFileCommandHandler = uploadFileCommandHandler ?? throw new ArgumentNullException(nameof(uploadFileCommandHandler));
 
       // ログ書き込みコマンドの初期化
       LogWriteCommand = new AsyncRelayCommand(ExecuteLogWriteAsync, CanExecuteLogWrite);
@@ -77,7 +77,8 @@ namespace AiDevTest1.WpfApp.ViewModels
         if (result.IsSuccess)
         {
           // ログ書き込み成功時のみファイルアップロードを実行
-          var uploadResult = await _fileUploadService.UploadLogFileAsync();
+          var uploadCommand = new UploadFileCommand();
+          var uploadResult = await _uploadFileCommandHandler.HandleAsync(uploadCommand);
           if (uploadResult.IsSuccess)
           {
             // 全処理成功


### PR DESCRIPTION
## Summary
- Issue #71 に対応し、ファイルアップロード処理にコマンドパターンを実装しました
- `IFileUploadService` の直接利用から `ICommandHandler<UploadFileCommand>` パターンへ移行

## Test plan
- [x] UploadFileCommandHandlerの単体テストを実装
- [x] 正常系・異常系のテストケースを網羅
- [x] MainWindowViewModelからコマンドハンドラー経由でファイルアップロードが実行されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)